### PR TITLE
added 'withSized', to convert an unsized vector to a sized vector with type parameter determined at runtime

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -213,6 +213,7 @@ module Data.Vector.Generic.Sized
   , fromList
   , fromListN
   , fromListN'
+  , withSizedList
     -- ** Other Vector types
   , convert
     -- ** Unsized Vectors
@@ -1526,6 +1527,17 @@ fromListN' :: forall v n a. (VG.Vector v a, KnownNat n)
            => Proxy n -> [a] -> Maybe (Vector v n a)
 fromListN' _ = fromListN
 {-# inline fromListN' #-}
+
+-- | /O(n)/ Takes a list and returns a continuation providing a vector with
+-- a size parameter corresponding to the length of the list.
+--
+-- Essentially converts a list into a vector with the proper size
+-- parameter, determined at runtime.
+--
+-- See 'withSized'
+withSizedList :: VG.Vector v a
+              => [a] -> (forall n. KnownNat n => Vector v n a -> r) -> r
+withSizedList xs = withSized (VG.fromList xs)
 
 -- ** Different Vector types
 

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -1535,7 +1535,7 @@ fromListN' _ = fromListN
 -- parameter, determined at runtime.
 --
 -- See 'withSized'
-withSizedList :: VG.Vector v a
+withSizedList :: forall v a r. VG.Vector v a
               => [a] -> (forall n. KnownNat n => Vector v n a -> r) -> r
 withSizedList xs = withSized (VG.fromList xs)
 
@@ -1566,11 +1566,8 @@ toSized v
 -- Essentially converts a 'Data.Vector.Generic.Vector' into
 -- a 'Data.Vector.Generic.Sized.Vector' with the correct size parameter
 -- @n@.
-withSized
-    :: forall v a r. VG.Vector v a
-    => v a
-    -> (forall n. KnownNat n => Vector v n a -> r)
-    -> r
+withSized :: forall v a r. VG.Vector v a
+          => v a -> (forall n. KnownNat n => Vector v n a -> r) -> r
 withSized v f = case someNatVal (fromIntegral (VG.length v)) of
     Just (SomeNat (Proxy :: Proxy n)) -> f (Vector v :: Vector v n a)
     Nothing -> error "withSized: VG.length returned negative length."

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -212,6 +212,7 @@ module Data.Vector.Sized
   , fromListN'
     -- ** Unsized Vectors
   , toSized
+  , withSized
   , fromSized
   , withVectorUnsafe
   ) where

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE RankNTypes #-}
 
 {-|
 This module re-exports the functionality in 'Data.Vector.Generic.Sized'
@@ -1401,6 +1402,20 @@ toSized :: forall n a. KnownNat n
         => VU.Vector a -> Maybe (Vector n a)
 toSized = V.toSized
 {-# inline toSized #-}
+
+-- | Takes a 'Data.Vector.Vector' and returns a continuation providing
+-- a 'Data.Vector.Sized.Vector' with a size parameter @n@ that is
+-- determined at runtime based on the length of the input vector.
+--
+-- Essentially converts a 'Data.Vector.Vector' into
+-- a 'Data.Vector.Sized.Vector' with the correct size parameter
+-- @n@.
+withSized
+    :: VU.Vector a
+    -> (forall n. KnownNat n => Vector n a -> r)
+    -> r
+withSized = V.withSized
+{-# inline withSized #-}
 
 fromSized :: Vector n a -> VU.Vector a
 fromSized = V.fromSized

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -210,6 +210,7 @@ module Data.Vector.Sized
   , fromList
   , fromListN
   , fromListN'
+  , withSizedList
     -- ** Unsized Vectors
   , toSized
   , withSized
@@ -1393,6 +1394,17 @@ fromListN' :: forall n a. KnownNat n
            => Proxy n -> [a] -> Maybe (Vector n a)
 fromListN' = V.fromListN'
 {-# inline fromListN' #-}
+
+-- | /O(n)/ Takes a list and returns a continuation providing a vector with
+-- a size parameter corresponding to the length of the list.
+--
+-- Essentially converts a list into a vector with the proper size
+-- parameter, determined at runtime.
+--
+-- See 'withSized'
+withSizedList :: [a] -> (forall n. KnownNat n => Vector n a -> r) -> r
+withSizedList xs = withSized (VU.fromList xs)
+{-# inline withSizedList #-}
 
 -- ** Unsized vectors
 

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -1402,7 +1402,7 @@ fromListN' = V.fromListN'
 -- parameter, determined at runtime.
 --
 -- See 'withSized'
-withSizedList :: [a] -> (forall n. KnownNat n => Vector n a -> r) -> r
+withSizedList :: forall a r. [a] -> (forall n. KnownNat n => Vector n a -> r) -> r
 withSizedList xs = withSized (VU.fromList xs)
 {-# inline withSizedList #-}
 
@@ -1423,10 +1423,7 @@ toSized = V.toSized
 -- Essentially converts a 'Data.Vector.Vector' into
 -- a 'Data.Vector.Sized.Vector' with the correct size parameter
 -- @n@.
-withSized
-    :: VU.Vector a
-    -> (forall n. KnownNat n => Vector n a -> r)
-    -> r
+withSized :: forall a r. VU.Vector a -> (forall n. KnownNat n => Vector n a -> r) -> r
 withSized = V.withSized
 {-# inline withSized #-}
 

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -212,6 +212,7 @@ module Data.Vector.Storable.Sized
   , fromListN'
     -- ** Unsized Vectors
   , toSized
+  , withSized
   , fromSized
   , withVectorUnsafe
   ) where

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE RankNTypes #-}
 
 {-|
 This module re-exports the functionality in 'Data.Vector.Generic.Sized'
@@ -1456,6 +1457,22 @@ toSized :: forall n a. (Storable a, KnownNat n)
         => VS.Vector a -> Maybe (Vector n a)
 toSized = V.toSized
 {-# inline toSized #-}
+
+-- | Takes a 'Data.Vector.Storable.Vector' and returns a continuation
+-- providing a 'Data.Vector.Storable.Sized.Vector' with a size parameter
+-- @n@ that is determined at runtime based on the length of the input
+-- vector.
+--
+-- Essentially converts a 'Data.Vector.Storable.Vector' into
+-- a 'Data.Vector.Storable.Sized.Vector' with the correct size parameter
+-- @n@.
+withSized
+    :: Storable a
+    => VS.Vector a
+    -> (forall n. KnownNat n => Vector n a -> r)
+    -> r
+withSized = V.withSized
+{-# inline withSized #-}
 
 fromSized :: Vector n a -> VS.Vector a
 fromSized = V.fromSized

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -210,6 +210,7 @@ module Data.Vector.Storable.Sized
   , fromList
   , fromListN
   , fromListN'
+  , withSizedList
     -- ** Unsized Vectors
   , toSized
   , withSized
@@ -1448,6 +1449,18 @@ fromListN' :: forall n a. (Storable a, KnownNat n)
            => Proxy n -> [a] -> Maybe (Vector n a)
 fromListN' = V.fromListN'
 {-# inline fromListN' #-}
+
+-- | /O(n)/ Takes a list and returns a continuation providing a vector with
+-- a size parameter corresponding to the length of the list.
+--
+-- Essentially converts a list into a vector with the proper size
+-- parameter, determined at runtime.
+--
+-- See 'withSized'
+withSizedList :: Storable a
+              => [a] -> (forall n. KnownNat n => Vector n a -> r) -> r
+withSizedList xs = withSized (VS.fromList xs)
+{-# inline withSizedList #-}
 
 -- ** Unsized vectors
 

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -1457,7 +1457,7 @@ fromListN' = V.fromListN'
 -- parameter, determined at runtime.
 --
 -- See 'withSized'
-withSizedList :: Storable a
+withSizedList :: forall a r. Storable a
               => [a] -> (forall n. KnownNat n => Vector n a -> r) -> r
 withSizedList xs = withSized (VS.fromList xs)
 {-# inline withSizedList #-}
@@ -1480,11 +1480,8 @@ toSized = V.toSized
 -- Essentially converts a 'Data.Vector.Storable.Vector' into
 -- a 'Data.Vector.Storable.Sized.Vector' with the correct size parameter
 -- @n@.
-withSized
-    :: Storable a
-    => VS.Vector a
-    -> (forall n. KnownNat n => Vector n a -> r)
-    -> r
+withSized :: forall a r. Storable a
+          => VS.Vector a -> (forall n. KnownNat n => Vector n a -> r) -> r
 withSized = V.withSized
 {-# inline withSized #-}
 


### PR DESCRIPTION
~~~
withSized
    :: VU.Vector a
    -> (forall n. KnownNat n => Vector n a -> r)
    -> r
~~~

example usage:

~~~
withSized (xs :: VU.Vector Double) $ \(xs' :: Vector n Double) ->
    ... do stuff with (xs' :: Vector n Double) here, where n is determined at runtime ...
~~~

A basic tool with using dependently typed size-indexed vectors :)  Pretty invaluable when working with sized vectors when the size of your vectors isn't known at compile-time.