### PR TITLE
Safe indexing with Finite instead of Int

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -300,8 +300,6 @@ index (Vector v) i = v `VG.unsafeIndex` fromIntegral i
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
---
--- __Deprecated__: Use 'index'.
 index' :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a)
        => Vector v (n+m+1) a -> Proxy n -> a
 index' (Vector v) p = v `VG.unsafeIndex` i
@@ -316,7 +314,7 @@ unsafeIndex :: forall v n a. (KnownNat n, VG.Vector v a)
 unsafeIndex (Vector v) i = v `VG.unsafeIndex` i
 {-# inline unsafeIndex #-}
 
-{-# deprecated index', unsafeIndex "Use index instead" #-}
+{-# deprecated unsafeIndex "Use index instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector.
 head :: forall v n a. (VG.Vector v a)
@@ -339,8 +337,6 @@ indexM (Vector v) i = v `VG.indexM` fromIntegral i
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
---
--- __Deprecated__: Use 'indexM'.
 indexM' :: forall v n k a m. (KnownNat n, KnownNat k, VG.Vector v a, Monad m)
       => Vector v (n+k) a -> Proxy n -> m a
 indexM' (Vector v) p = v `VG.indexM` i
@@ -356,7 +352,7 @@ unsafeIndexM :: forall v n a m. (KnownNat n, VG.Vector v a, Monad m)
 unsafeIndexM (Vector v) i = v `VG.unsafeIndexM` i
 {-# inline unsafeIndexM #-}
 
-{-# deprecated indexM', unsafeIndexM "Use indexM instead" #-}
+{-# deprecated unsafeIndexM "Use indexM instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -227,6 +227,7 @@ import qualified Data.Vector.Generic as VG
 import qualified Data.Vector as Boxed
 import GHC.Generics (Generic)
 import GHC.TypeLits
+import Data.Finite
 import Data.Proxy
 import Control.DeepSeq (NFData)
 import Foreign.Storable
@@ -292,13 +293,15 @@ length' :: forall v n a. (KnownNat n)
 length' _ = Proxy
 {-# inline length' #-}
 
--- | /O(1)/ Indexing using an Int.
+-- | /O(1)/ Safe indexing using a 'Finite'.
 index :: forall v n a. (KnownNat n, VG.Vector v a)
-      => Vector v n a -> Int -> a
-index (Vector v) i = v VG.! i
+      => Vector v n a -> Finite n -> a
+index (Vector v) i = v `VG.unsafeIndex` fromIntegral i
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
+--
+-- __Deprecated__: Use 'index'.
 index' :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a)
        => Vector v (n+m+1) a -> Proxy n -> a
 index' (Vector v) p = v `VG.unsafeIndex` i
@@ -306,10 +309,14 @@ index' (Vector v) p = v `VG.unsafeIndex` i
 {-# inline index' #-}
 
 -- | /O(1)/ Indexing using an Int without bounds checking.
+--
+-- __Deprecated__: Use 'index'.
 unsafeIndex :: forall v n a. (KnownNat n, VG.Vector v a)
       => Vector v n a -> Int -> a
 unsafeIndex (Vector v) i = v `VG.unsafeIndex` i
 {-# inline unsafeIndex #-}
+
+{-# deprecated index', unsafeIndex "Use index instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector.
 head :: forall v n a. (VG.Vector v a)
@@ -323,15 +330,17 @@ last :: forall v n a. (VG.Vector v a)
 last (Vector v) = VG.unsafeLast v
 {-# inline last #-}
 
--- | /O(1)/ Indexing in a monad. See the documentation for 'VG.indexM' for an
--- explanation of why this is useful.
+-- | /O(1)/ Safe indexing in a monad. See the documentation for 'VG.indexM' for
+-- an explanation of why this is useful.
 indexM :: forall v n a m. (KnownNat n, VG.Vector v a, Monad m)
-      => Vector v n a -> Int -> m a
-indexM (Vector v) i = v `VG.indexM` i
+      => Vector v n a -> Finite n -> m a
+indexM (Vector v) i = v `VG.indexM` fromIntegral i
 {-# inline indexM #-}
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
+--
+-- __Deprecated__: Use 'indexM'.
 indexM' :: forall v n k a m. (KnownNat n, KnownNat k, VG.Vector v a, Monad m)
       => Vector v (n+k) a -> Proxy n -> m a
 indexM' (Vector v) p = v `VG.indexM` i
@@ -340,10 +349,14 @@ indexM' (Vector v) p = v `VG.indexM` i
 
 -- | /O(1)/ Indexing using an Int without bounds checking. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
+--
+-- __Deprecated__: Use 'indexM'.
 unsafeIndexM :: forall v n a m. (KnownNat n, VG.Vector v a, Monad m)
       => Vector v n a -> Int -> m a
 unsafeIndexM (Vector v) i = v `VG.unsafeIndexM` i
 {-# inline unsafeIndexM #-}
+
+{-# deprecated indexM', unsafeIndexM "Use indexM instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -261,8 +261,6 @@ index = V.index
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
---
--- __Deprecated__: Use 'index'.
 index' :: forall n m a. (KnownNat n, KnownNat m)
        => Vector (n+m+1) a -> Proxy n -> a
 index' = V.index'
@@ -276,7 +274,7 @@ unsafeIndex :: forall n a. KnownNat n
 unsafeIndex = V.unsafeIndex
 {-# inline unsafeIndex #-}
 
-{-# deprecated index', unsafeIndex "Use index instead" #-}
+{-# deprecated unsafeIndex "Use index instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector.
 head :: forall n a. Vector (n+1) a -> a
@@ -297,8 +295,6 @@ indexM = V.indexM
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
---
--- __Deprecated__: Use 'indexM'.
 indexM' :: forall n k a m. (KnownNat n, KnownNat k, Monad m)
       => Vector (n+k) a -> Proxy n -> m a
 indexM' = V.indexM'
@@ -313,7 +309,7 @@ unsafeIndexM :: forall n a m. (KnownNat n, Monad m)
 unsafeIndexM = V.unsafeIndexM
 {-# inline unsafeIndexM #-}
 
-{-# deprecated indexM', unsafeIndexM "Use indexM instead" #-}
+{-# deprecated unsafeIndexM "Use indexM instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -55,6 +55,7 @@ module Data.Vector.Sized
   , replicate'
   , generate
   , generate'
+  , generate_
   , iterateN
   , iterateN'
     -- ** Monadic initialization
@@ -62,6 +63,7 @@ module Data.Vector.Sized
   , replicateM'
   , generateM
   , generateM'
+  , generateM_
     -- ** Unfolding
   , unfoldrN
   , unfoldrN'
@@ -449,6 +451,16 @@ generate' :: forall n a. KnownNat n
 generate' = V.generate'
 {-# inline generate' #-}
 
+-- | /O(n)/ construct a vector of the given length by applying the function to
+-- each index where the length is inferred from the type.
+--
+-- The function can expect a @'Finite' n@, meaning that its input will
+-- always be between @0@ and @n - 1@.
+generate_ :: forall n a. KnownNat n
+          => (Finite n -> a) -> Vector n a
+generate_ = V.generate_
+{-# inline generate_ #-}
+
 -- | /O(n)/ Apply function n times to value. Zeroth element is original value.
 -- The length is inferred from the type.
 iterateN :: forall n a. KnownNat n
@@ -487,6 +499,16 @@ generateM :: forall n m a. (KnownNat n, Monad m)
           => (Int -> m a) -> m (Vector n a)
 generateM = V.generateM
 {-# inline generateM #-}
+
+-- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
+-- each index where n is inferred from the type.
+--
+-- The function can expect a @'Finite' n@, meaning that its input will
+-- always be between @0@ and @n - 1@.
+generateM_ :: forall n m a. (KnownNat n, Monad m)
+           => (Finite n -> m a) -> m (Vector n a)
+generateM_ = V.generateM_
+{-# inline generateM_ #-}
 
 -- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
 -- each index where n is given explicitly as a 'Proxy' argument.

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -221,6 +221,7 @@ module Data.Vector.Sized
 import qualified Data.Vector.Generic.Sized as V
 import qualified Data.Vector as VU
 import GHC.TypeLits
+import Data.Finite
 import Data.Proxy
 import Prelude hiding ( length, null,
                         replicate, (++), concat,
@@ -253,23 +254,29 @@ length' :: forall n a. KnownNat n
 length' = V.length'
 {-# inline length' #-}
 
--- | /O(1)/ Indexing using an Int.
+-- | /O(1)/ Safe indexing using a 'Finite'.
 index :: forall n a. KnownNat n
-      => Vector n a -> Int -> a
+      => Vector n a -> Finite n -> a
 index = V.index
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
+--
+-- __Deprecated__: Use 'index'.
 index' :: forall n m a. (KnownNat n, KnownNat m)
        => Vector (n+m+1) a -> Proxy n -> a
 index' = V.index'
 {-# inline index' #-}
 
 -- | /O(1)/ Indexing using an Int without bounds checking.
+--
+-- __Deprecated__: Use 'index'.
 unsafeIndex :: forall n a. KnownNat n
       => Vector n a -> Int -> a
 unsafeIndex = V.unsafeIndex
 {-# inline unsafeIndex #-}
+
+{-# deprecated index', unsafeIndex "Use index instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector.
 head :: forall n a. Vector (n+1) a -> a
@@ -281,15 +288,17 @@ last :: forall n a. Vector (n+1) a -> a
 last = V.last
 {-# inline last #-}
 
--- | /O(1)/ Indexing in a monad. See the documentation for 'VG.indexM' for an
--- explanation of why this is useful.
+-- | /O(1)/ Safe indexing in a monad. See the documentation for 'VG.indexM' for
+-- an explanation of why this is useful.
 indexM :: forall n a m. (KnownNat n, Monad m)
-      => Vector n a -> Int -> m a
+      => Vector n a -> Finite n -> m a
 indexM = V.indexM
 {-# inline indexM #-}
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
+--
+-- __Deprecated__: Use 'indexM'.
 indexM' :: forall n k a m. (KnownNat n, KnownNat k, Monad m)
       => Vector (n+k) a -> Proxy n -> m a
 indexM' = V.indexM'
@@ -297,10 +306,14 @@ indexM' = V.indexM'
 
 -- | /O(1)/ Indexing using an Int without bounds checking. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
+--
+-- __Deprecated__: Use 'indexM'.
 unsafeIndexM :: forall n a m. (KnownNat n, Monad m)
       => Vector n a -> Int -> m a
 unsafeIndexM = V.unsafeIndexM
 {-# inline unsafeIndexM #-}
+
+{-# deprecated indexM', unsafeIndexM "Use indexM instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -55,6 +55,7 @@ module Data.Vector.Storable.Sized
   , replicate'
   , generate
   , generate'
+  , generate_
   , iterateN
   , iterateN'
     -- ** Monadic initialization
@@ -62,6 +63,7 @@ module Data.Vector.Storable.Sized
   , replicateM'
   , generateM
   , generateM'
+  , generateM_
     -- ** Unfolding
   , unfoldrN
   , unfoldrN'
@@ -456,6 +458,16 @@ generate' :: forall n a. (KnownNat n, Storable a)
 generate' = V.generate'
 {-# inline generate' #-}
 
+-- | /O(n)/ construct a vector of the given length by applying the function to
+-- each index where the length is inferred from the type.
+--
+-- The function can expect a @'Finite' n@, meaning that its input will
+-- always be between @0@ and @n - 1@.
+generate_ :: forall n a. (KnownNat n, Storable a)
+          => (Finite n -> a) -> Vector n a
+generate_ = V.generate_
+{-# inline generate_ #-}
+
 -- | /O(n)/ Apply function n times to value. Zeroth element is original value.
 -- The length is inferred from the type.
 iterateN :: forall n a. (KnownNat n, Storable a)
@@ -501,6 +513,16 @@ generateM' :: forall n m a. (KnownNat n, Storable a, Monad m)
            => Proxy n -> (Int -> m a) -> m (Vector n a)
 generateM' = V.generateM'
 {-# inline generateM' #-}
+
+-- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
+-- each index where n is inferred from the type.
+--
+-- The function can expect a @'Finite' n@, meaning that its input will
+-- always be between @0@ and @n - 1@.
+generateM_ :: forall n m a. (KnownNat n, Storable a, Monad m)
+           => (Finite n -> m a) -> m (Vector n a)
+generateM_ = V.generateM_
+{-# inline generateM_ #-}
 
 --
 -- ** Unfolding

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -262,8 +262,6 @@ index = V.index
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
---
--- __Deprecated__: Use 'index'.
 index' :: forall n m a. (KnownNat n, KnownNat m, Storable a)
        => Vector (n+m+1) a -> Proxy n -> a
 index' = V.index'
@@ -277,7 +275,7 @@ unsafeIndex :: forall n a. (KnownNat n, Storable a)
 unsafeIndex = V.unsafeIndex
 {-# inline unsafeIndex #-}
 
-{-# deprecated index', unsafeIndex "Use index instead" #-}
+{-# deprecated unsafeIndex "Use index instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector.
 head :: forall n a. (Storable a)
@@ -300,8 +298,6 @@ indexM = V.indexM
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
---
--- __Deprecated__: Use 'indexM'.
 indexM' :: forall n k a m. (KnownNat n, KnownNat k, Storable a, Monad m)
       => Vector (n+k) a -> Proxy n -> m a
 indexM' = V.indexM'
@@ -316,7 +312,7 @@ unsafeIndexM :: forall n a m. (KnownNat n, Storable a, Monad m)
 unsafeIndexM = V.unsafeIndexM
 {-# inline unsafeIndexM #-}
 
-{-# deprecated indexM', unsafeIndexM "Use indexM instead" #-}
+{-# deprecated unsafeIndexM "Use indexM instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -221,6 +221,7 @@ module Data.Vector.Storable.Sized
 import qualified Data.Vector.Generic.Sized as V
 import qualified Data.Vector.Storable as VS
 import GHC.TypeLits
+import Data.Finite
 import Data.Proxy
 import Foreign.Storable
 import Prelude hiding ( length, null,
@@ -254,23 +255,29 @@ length' :: forall n a. (KnownNat n)
 length' = V.length'
 {-# inline length' #-}
 
--- | /O(1)/ Indexing using an Int.
+-- | /O(1)/ Safe indexing using a 'Finite'.
 index :: forall n a. (KnownNat n, Storable a)
-      => Vector n a -> Int -> a
+      => Vector n a -> Finite n -> a
 index = V.index
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
+--
+-- __Deprecated__: Use 'index'.
 index' :: forall n m a. (KnownNat n, KnownNat m, Storable a)
        => Vector (n+m+1) a -> Proxy n -> a
 index' = V.index'
 {-# inline index' #-}
 
 -- | /O(1)/ Indexing using an Int without bounds checking.
+--
+-- __Deprecated__: Use 'index'.
 unsafeIndex :: forall n a. (KnownNat n, Storable a)
       => Vector n a -> Int -> a
 unsafeIndex = V.unsafeIndex
 {-# inline unsafeIndex #-}
+
+{-# deprecated index', unsafeIndex "Use index instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector.
 head :: forall n a. (Storable a)
@@ -284,15 +291,17 @@ last :: forall n a. (Storable a)
 last = V.last
 {-# inline last #-}
 
--- | /O(1)/ Indexing in a monad. See the documentation for 'VG.indexM' for an
--- explanation of why this is useful.
+-- | /O(1)/ Safe indexing in a monad. See the documentation for 'VG.indexM' for
+-- an explanation of why this is useful.
 indexM :: forall n a m. (KnownNat n, Storable a, Monad m)
-      => Vector n a -> Int -> m a
+      => Vector n a -> Finite n -> m a
 indexM = V.indexM
 {-# inline indexM #-}
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
+--
+-- __Deprecated__: Use 'indexM'.
 indexM' :: forall n k a m. (KnownNat n, KnownNat k, Storable a, Monad m)
       => Vector (n+k) a -> Proxy n -> m a
 indexM' = V.indexM'
@@ -300,10 +309,14 @@ indexM' = V.indexM'
 
 -- | /O(1)/ Indexing using an Int without bounds checking. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
+--
+-- __Deprecated__: Use 'indexM'.
 unsafeIndexM :: forall n a m. (KnownNat n, Storable a, Monad m)
       => Vector n a -> Int -> m a
 unsafeIndexM = V.unsafeIndexM
 {-# inline unsafeIndexM #-}
+
+{-# deprecated indexM', unsafeIndexM "Use indexM instead" #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@
 resolver: lts-7.10
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- finite-typelits-0.1.0.0
 flags: {}
 extra-package-dbs: []

--- a/vector-sized.cabal
+++ b/vector-sized.cabal
@@ -22,6 +22,7 @@ library
   build-depends:       base >= 4.9 && < 5
                      , vector >= 0.11 && < 0.12
                      , deepseq >= 1.1 && < 1.5
+                     , finite-typelits >= 0.1
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
Because we have the length of the vector in the index, we should be able to do type-safe indexing using the appropriate data type.

`Finite` comes from the [finite-typelits](http://hackage.haskell.org/package/finite-typelits) package, and a `Finite n` is a type with distinct `n` inhabitants.  Its `Num` and `Integral` instances treat it as a number from 0 to (n-1), so we can use it directly as an index.

There is a call to `fromIntegral` in the process, but rewrite rules in theory (depending on how `Data.Finite` is implemented) should make this costless/have no overhead.

We can use `VG.unsafeIndex` for the `index` function for the sized vectors, so we can do unsafe indexing under the hood w/o bounds checking.

This is a breaking change, so I'm not sure how best to approach this if you decide that you do like this change.  Maybe it could be given a different name instead of replacing `index`?