### PR TITLE
loosened upper bounds on vector dependency for stackage compatibility

### DIFF
--- a/vector-sized.cabal
+++ b/vector-sized.cabal
@@ -20,7 +20,7 @@ library
                      , Data.Vector.Generic.Sized
                      , Data.Vector.Storable.Sized
   build-depends:       base >= 4.9 && < 5
-                     , vector >= 0.11 && < 0.12
+                     , vector >= 0.11 && < 0.13
                      , deepseq >= 1.1 && < 1.5
                      , finite-typelits >= 0.1
   default-language:    Haskell2010


### PR DESCRIPTION
As per https://github.com/fpco/stackage/issues/2194 , stackage is planning on moving to vector-0.12.0.0, so this is just a dependency bump for compatibility!  The package installs without any errors or warnings with vector-0.12, but I can't be 100% sure that there aren't any potential regressions.