### PR TITLE
Allow functions that take `Proxy n` to take any `p n`, as per modern Haskell convention

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -303,8 +303,8 @@ index (Vector v) i = v `VG.unsafeIndex` fromIntegral i
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
-index' :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a)
-       => Vector v (n+m+1) a -> Proxy n -> a
+index' :: forall v n m a p. (KnownNat n, KnownNat m, VG.Vector v a)
+       => Vector v (n+m+1) a -> p n -> a
 index' (Vector v) p = v `VG.unsafeIndex` i
   where i = fromInteger (natVal p)
 {-# inline index' #-}
@@ -336,8 +336,8 @@ indexM (Vector v) i = v `VG.indexM` fromIntegral i
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
-indexM' :: forall v n k a m. (KnownNat n, KnownNat k, VG.Vector v a, Monad m)
-      => Vector v (n+k) a -> Proxy n -> m a
+indexM' :: forall v n k a m p. (KnownNat n, KnownNat k, VG.Vector v a, Monad m)
+      => Vector v (n+k) a -> p n -> m a
 indexM' (Vector v) p = v `VG.indexM` i
   where i = fromInteger (natVal p)
 {-# inline indexM' #-}
@@ -365,8 +365,8 @@ lastM (Vector v) = VG.unsafeLastM v
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an inferred
 -- length argument.
-slice :: forall v i n a. (KnownNat i, KnownNat n, VG.Vector v a)
-      => Proxy i -- ^ starting index
+slice :: forall v i n a p. (KnownNat i, KnownNat n, VG.Vector v a)
+      => p i -- ^ starting index
       -> Vector v (i+n) a
       -> Vector v n a
 slice start (Vector v) = Vector (VG.unsafeSlice i n v)
@@ -376,9 +376,9 @@ slice start (Vector v) = Vector (VG.unsafeSlice i n v)
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an explicit
 -- length argument.
-slice' :: forall v i n a. (KnownNat i, KnownNat n, VG.Vector v a)
-       => Proxy i -- ^ starting index
-       -> Proxy n -- ^ length
+slice' :: forall v i n a p. (KnownNat i, KnownNat n, VG.Vector v a)
+       => p i -- ^ starting index
+       -> p n -- ^ length
        -> Vector v (i+n) a
        -> Vector v n a
 slice' start _ = slice start
@@ -410,8 +410,8 @@ take (Vector v) = Vector (VG.unsafeTake i v)
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is given explicitly
 -- as a 'Proxy' argument.
-take' :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a)
-      => Proxy n -> Vector v (m+n) a -> Vector v n a
+take' :: forall v n m a p. (KnownNat n, KnownNat m, VG.Vector v a)
+      => p n -> Vector v (m+n) a -> Vector v n a
 take' _ = take
 {-# inline take' #-}
 
@@ -427,8 +427,8 @@ drop (Vector v) = Vector (VG.unsafeDrop i v)
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- givel explicitly as a 'Proxy' argument.
-drop' :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a)
-      => Proxy n -> Vector v (m+n) a -> Vector v m a
+drop' :: forall v n m a p. (KnownNat n, KnownNat m, VG.Vector v a)
+      => p n -> Vector v (m+n) a -> Vector v m a
 drop' _ = drop
 {-# inline drop' #-}
 
@@ -444,8 +444,8 @@ splitAt (Vector v) = (Vector a, Vector b)
 -- | /O(1)/ Yield the first n elements paired with the remainder without
 -- copying.  The length of the first resultant vector is passed explicitly as a
 -- 'Proxy' argument.
-splitAt' :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a)
-         => Proxy n -> Vector v (n+m) a -> (Vector v n a, Vector v m a)
+splitAt' :: forall v n m a p. (KnownNat n, KnownNat m, VG.Vector v a)
+         => p n -> Vector v (n+m) a -> (Vector v n a, Vector v m a)
 splitAt' _ = splitAt
 {-# inline splitAt' #-}
 
@@ -479,8 +479,8 @@ replicate a = Vector (VG.replicate i a)
 
 -- | /O(n)/ Construct a vector with the same element in each position where the
 -- length is given explicitly as a 'Proxy' argument.
-replicate' :: forall v n a. (KnownNat n, VG.Vector v a)
-           => Proxy n -> a -> Vector v n a
+replicate' :: forall v n a p. (KnownNat n, VG.Vector v a)
+           => p n -> a -> Vector v n a
 replicate' _ = replicate
 {-# inline replicate' #-}
 
@@ -494,8 +494,8 @@ generate f = Vector (VG.generate i f)
 
 -- | /O(n)/ construct a vector of the given length by applying the function to
 -- each index where the length is given explicitly as a 'Proxy' argument.
-generate' :: forall v n a. (KnownNat n, VG.Vector v a)
-          => Proxy n -> (Int -> a) -> Vector v n a
+generate' :: forall v n a p. (KnownNat n, VG.Vector v a)
+          => p n -> (Int -> a) -> Vector v n a
 generate' _ = generate
 {-# inline generate' #-}
 
@@ -520,8 +520,8 @@ iterateN f z = Vector (VG.iterateN i f z)
 
 -- | /O(n)/ Apply function n times to value. Zeroth element is original value.
 -- The length is given explicitly as a 'Proxy' argument.
-iterateN' :: forall v n a. (KnownNat n, VG.Vector v a)
-          => Proxy n -> (a -> a) -> a -> Vector v n a
+iterateN' :: forall v n a p. (KnownNat n, VG.Vector v a)
+          => p n -> (a -> a) -> a -> Vector v n a
 iterateN' _ = iterateN
 {-# inline iterateN' #-}
 
@@ -539,8 +539,8 @@ replicateM a = Vector <$> VG.replicateM i a
 
 -- | /O(n)/ Execute the monadic action @n@ times and store the results in a
 -- vector where @n@ is given explicitly as a 'Proxy' argument.
-replicateM' :: forall v n m a. (KnownNat n, VG.Vector v a, Monad m)
-            => Proxy n -> m a -> m (Vector v n a)
+replicateM' :: forall v n m a p. (KnownNat n, VG.Vector v a, Monad m)
+            => p n -> m a -> m (Vector v n a)
 replicateM' _ = replicateM
 {-# inline replicateM' #-}
 
@@ -554,8 +554,8 @@ generateM f = Vector <$> VG.generateM i f
 
 -- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
 -- each index where n is given explicitly as a 'Proxy' argument.
-generateM' :: forall v n m a. (KnownNat n, VG.Vector v a, Monad m)
-           => Proxy n -> (Int -> m a) -> m (Vector v n a)
+generateM' :: forall v n m a p. (KnownNat n, VG.Vector v a, Monad m)
+           => p n -> (Int -> m a) -> m (Vector v n a)
 generateM' _ = generateM
 {-# inline generateM' #-}
 
@@ -586,8 +586,8 @@ unfoldrN f z = Vector (VG.unfoldrN i (Just . f) z)
 -- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to the a seed. The length, @n@, is given explicitly
 -- as a 'Proxy' argument.
-unfoldrN' :: forall v n a b. (KnownNat n, VG.Vector v a)
-          => Proxy n -> (b -> (a, b)) -> b -> Vector v n a
+unfoldrN' :: forall v n a b p. (KnownNat n, VG.Vector v a)
+          => p n -> (b -> (a, b)) -> b -> Vector v n a
 unfoldrN' _ = unfoldrN
 {-# inline unfoldrN' #-}
 
@@ -605,8 +605,8 @@ enumFromN a = Vector (VG.enumFromN a i)
 
 -- | /O(n)/ Yield a vector of length @n@ containing the values @x@, @x+1@
 -- etc. The length, @n@, is given explicitly as a 'Proxy' argument.
-enumFromN' :: forall v n a. (KnownNat n, VG.Vector v a, Num a)
-           => a -> Proxy n -> Vector v n a
+enumFromN' :: forall v n a p. (KnownNat n, VG.Vector v a, Num a)
+           => a -> p n -> Vector v n a
 enumFromN' a _ = enumFromN a
 {-# inline enumFromN' #-}
 
@@ -620,8 +620,8 @@ enumFromStepN a a' = Vector (VG.enumFromStepN a a' i)
 
 -- | /O(n)/ Yield a vector of the given length containing the values @x@, @x+y@,
 -- @x+y+y@ etc. The length, @n@, is given explicitly as a 'Proxy' argument.
-enumFromStepN' :: forall v n a. (KnownNat n, VG.Vector v a, Num a)
-               => a -> a -> Proxy n -> Vector v n a
+enumFromStepN' :: forall v n a p. (KnownNat n, VG.Vector v a, Num a)
+               => a -> a -> p n -> Vector v n a
 enumFromStepN' a a' _ = enumFromStepN a a'
 {-# inline enumFromStepN' #-}
 
@@ -1549,8 +1549,8 @@ fromListN = toSized . VG.fromListN i
 
 -- | /O(n)/ Convert the first @n@ elements of a list to a vector. The length of
 -- the resultant vector is given explicitly as a 'Proxy' argument.
-fromListN' :: forall v n a. (VG.Vector v a, KnownNat n) 
-           => Proxy n -> [a] -> Maybe (Vector v n a)
+fromListN' :: forall v n a p. (VG.Vector v a, KnownNat n) 
+           => p n -> [a] -> Maybe (Vector v n a)
 fromListN' _ = fromListN
 {-# inline fromListN' #-}
 

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -263,8 +263,8 @@ index = V.index
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
-index' :: forall n m a. (KnownNat n, KnownNat m)
-       => Vector (n+m+1) a -> Proxy n -> a
+index' :: forall n m a p. (KnownNat n, KnownNat m)
+       => Vector (n+m+1) a -> p n -> a
 index' = V.index'
 {-# inline index' #-}
 
@@ -293,8 +293,8 @@ indexM = V.indexM
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
-indexM' :: forall n k a m. (KnownNat n, KnownNat k, Monad m)
-      => Vector (n+k) a -> Proxy n -> m a
+indexM' :: forall n k a m p. (KnownNat n, KnownNat k, Monad m)
+      => Vector (n+k) a -> p n -> m a
 indexM' = V.indexM'
 {-# inline indexM' #-}
 
@@ -321,8 +321,8 @@ lastM = V.lastM
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an inferred
 -- length argument.
-slice :: forall i n a. (KnownNat i, KnownNat n)
-      => Proxy i -- ^ starting index
+slice :: forall i n a p. (KnownNat i, KnownNat n)
+      => p i -- ^ starting index
       -> Vector (i+n) a
       -> Vector n a
 slice = V.slice
@@ -330,9 +330,9 @@ slice = V.slice
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an explicit
 -- length argument.
-slice' :: forall i n a. (KnownNat i, KnownNat n)
-       => Proxy i -- ^ starting index
-       -> Proxy n -- ^ length
+slice' :: forall i n a p. (KnownNat i, KnownNat n)
+       => p i -- ^ starting index
+       -> p n -- ^ length
        -> Vector (i+n) a
        -> Vector n a
 slice' = V.slice'
@@ -361,8 +361,8 @@ take = V.take
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is given explicitly
 -- as a 'Proxy' argument.
-take' :: forall n m a. (KnownNat n, KnownNat m)
-      => Proxy n -> Vector (m+n) a -> Vector n a
+take' :: forall n m a p. (KnownNat n, KnownNat m)
+      => p n -> Vector (m+n) a -> Vector n a
 take' = V.take'
 {-# inline take' #-}
 
@@ -377,8 +377,8 @@ drop = V.drop
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- givel explicitly as a 'Proxy' argument.
-drop' :: forall n m a. (KnownNat n, KnownNat m)
-      => Proxy n -> Vector (m+n) a -> Vector m a
+drop' :: forall n m a p. (KnownNat n, KnownNat m)
+      => p n -> Vector (m+n) a -> Vector m a
 drop' = V.drop'
 {-# inline drop' #-}
 
@@ -392,8 +392,8 @@ splitAt = V.splitAt
 -- | /O(1)/ Yield the first n elements paired with the remainder without
 -- copying.  The length of the first resultant vector is passed explicitly as a
 -- 'Proxy' argument.
-splitAt' :: forall n m a. (KnownNat n, KnownNat m)
-         => Proxy n -> Vector (n+m) a -> (Vector n a, Vector m a)
+splitAt' :: forall n m a p. (KnownNat n, KnownNat m)
+         => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
 
@@ -424,8 +424,8 @@ replicate = V.replicate
 
 -- | /O(n)/ Construct a vector with the same element in each position where the
 -- length is given explicitly as a 'Proxy' argument.
-replicate' :: forall n a. KnownNat n
-           => Proxy n -> a -> Vector n a
+replicate' :: forall n a p. KnownNat n
+           => p n -> a -> Vector n a
 replicate' = V.replicate'
 {-# inline replicate' #-}
 
@@ -438,8 +438,8 @@ generate = V.generate
 
 -- | /O(n)/ construct a vector of the given length by applying the function to
 -- each index where the length is given explicitly as a 'Proxy' argument.
-generate' :: forall n a. KnownNat n
-          => Proxy n -> (Int -> a) -> Vector n a
+generate' :: forall n a p. KnownNat n
+          => p n -> (Int -> a) -> Vector n a
 generate' = V.generate'
 {-# inline generate' #-}
 
@@ -462,8 +462,8 @@ iterateN = V.iterateN
 
 -- | /O(n)/ Apply function n times to value. Zeroth element is original value.
 -- The length is given explicitly as a 'Proxy' argument.
-iterateN' :: forall n a. KnownNat n
-          => Proxy n -> (a -> a) -> a -> Vector n a
+iterateN' :: forall n a p. KnownNat n
+          => p n -> (a -> a) -> a -> Vector n a
 iterateN' = V.iterateN'
 {-# inline iterateN' #-}
 
@@ -480,8 +480,8 @@ replicateM = V.replicateM
 
 -- | /O(n)/ Execute the monadic action @n@ times and store the results in a
 -- vector where @n@ is given explicitly as a 'Proxy' argument.
-replicateM' :: forall n m a. (KnownNat n, Monad m)
-            => Proxy n -> m a -> m (Vector n a)
+replicateM' :: forall n m a p. (KnownNat n, Monad m)
+            => p n -> m a -> m (Vector n a)
 replicateM' = V.replicateM'
 {-# inline replicateM' #-}
 
@@ -504,8 +504,8 @@ generateM_ = V.generateM_
 
 -- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
 -- each index where n is given explicitly as a 'Proxy' argument.
-generateM' :: forall n m a. (KnownNat n, Monad m)
-           => Proxy n -> (Int -> m a) -> m (Vector n a)
+generateM' :: forall n m a p. (KnownNat n, Monad m)
+           => p n -> (Int -> m a) -> m (Vector n a)
 generateM' = V.generateM'
 {-# inline generateM' #-}
 
@@ -524,8 +524,8 @@ unfoldrN = V.unfoldrN
 -- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to the a seed. The length, @n@, is given explicitly
 -- as a 'Proxy' argument.
-unfoldrN' :: forall n a b. KnownNat n
-          => Proxy n -> (b -> (a, b)) -> b -> Vector n a
+unfoldrN' :: forall n a b p. KnownNat n
+          => p n -> (b -> (a, b)) -> b -> Vector n a
 unfoldrN' = V.unfoldrN'
 {-# inline unfoldrN' #-}
 
@@ -542,8 +542,8 @@ enumFromN = V.enumFromN
 
 -- | /O(n)/ Yield a vector of length @n@ containing the values @x@, @x+1@
 -- etc. The length, @n@, is given explicitly as a 'Proxy' argument.
-enumFromN' :: forall n a. (KnownNat n, Num a)
-           => a -> Proxy n -> Vector n a
+enumFromN' :: forall n a p. (KnownNat n, Num a)
+           => a -> p n -> Vector n a
 enumFromN' = V.enumFromN'
 {-# inline enumFromN' #-}
 
@@ -556,8 +556,8 @@ enumFromStepN = V.enumFromStepN
 
 -- | /O(n)/ Yield a vector of the given length containing the values @x@, @x+y@,
 -- @x+y+y@ etc. The length, @n@, is given explicitly as a 'Proxy' argument.
-enumFromStepN' :: forall n a. (KnownNat n, Num a)
-               => a -> a -> Proxy n -> Vector n a
+enumFromStepN' :: forall n a p. (KnownNat n, Num a)
+               => a -> a -> p n -> Vector n a
 enumFromStepN' = V.enumFromStepN'
 {-# inline enumFromStepN' #-}
 
@@ -1413,8 +1413,8 @@ fromListN = V.fromListN
 
 -- | /O(n)/ Convert the first @n@ elements of a list to a vector. The length of
 -- the resultant vector is given explicitly as a 'Proxy' argument.
-fromListN' :: forall n a. KnownNat n
-           => Proxy n -> [a] -> Maybe (Vector n a)
+fromListN' :: forall n a p. KnownNat n
+           => p n -> [a] -> Maybe (Vector n a)
 fromListN' = V.fromListN'
 {-# inline fromListN' #-}
 

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -264,8 +264,8 @@ index = V.index
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
-index' :: forall n m a. (KnownNat n, KnownNat m, Storable a)
-       => Vector (n+m+1) a -> Proxy n -> a
+index' :: forall n m a p. (KnownNat n, KnownNat m, Storable a)
+       => Vector (n+m+1) a -> p n -> a
 index' = V.index'
 {-# inline index' #-}
 
@@ -296,8 +296,8 @@ indexM = V.indexM
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
-indexM' :: forall n k a m. (KnownNat n, KnownNat k, Storable a, Monad m)
-      => Vector (n+k) a -> Proxy n -> m a
+indexM' :: forall n k a m p. (KnownNat n, KnownNat k, Storable a, Monad m)
+      => Vector (n+k) a -> p n -> m a
 indexM' = V.indexM'
 {-# inline indexM' #-}
 
@@ -324,8 +324,8 @@ lastM = V.lastM
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an inferred
 -- length argument.
-slice :: forall i n a. (KnownNat i, KnownNat n, Storable a)
-      => Proxy i -- ^ starting index
+slice :: forall i n a p. (KnownNat i, KnownNat n, Storable a)
+      => p i -- ^ starting index
       -> Vector (i+n) a
       -> Vector n a
 slice = V.slice
@@ -333,9 +333,9 @@ slice = V.slice
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an explicit
 -- length argument.
-slice' :: forall i n a. (KnownNat i, KnownNat n, Storable a)
-       => Proxy i -- ^ starting index
-       -> Proxy n -- ^ length
+slice' :: forall i n a p. (KnownNat i, KnownNat n, Storable a)
+       => p i -- ^ starting index
+       -> p n -- ^ length
        -> Vector (i+n) a
        -> Vector n a
 slice' = V.slice'
@@ -366,8 +366,8 @@ take = V.take
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is given explicitly
 -- as a 'Proxy' argument.
-take' :: forall n m a. (KnownNat n, KnownNat m, Storable a)
-      => Proxy n -> Vector (m+n) a -> Vector n a
+take' :: forall n m a p. (KnownNat n, KnownNat m, Storable a)
+      => p n -> Vector (m+n) a -> Vector n a
 take' = V.take'
 {-# inline take' #-}
 
@@ -382,8 +382,8 @@ drop = V.drop
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- givel explicitly as a 'Proxy' argument.
-drop' :: forall n m a. (KnownNat n, KnownNat m, Storable a)
-      => Proxy n -> Vector (m+n) a -> Vector m a
+drop' :: forall n m a p. (KnownNat n, KnownNat m, Storable a)
+      => p n -> Vector (m+n) a -> Vector m a
 drop' = V.drop'
 {-# inline drop' #-}
 
@@ -397,8 +397,8 @@ splitAt = V.splitAt
 -- | /O(1)/ Yield the first n elements paired with the remainder without
 -- copying.  The length of the first resultant vector is passed explicitly as a
 -- 'Proxy' argument.
-splitAt' :: forall n m a. (KnownNat n, KnownNat m, Storable a)
-         => Proxy n -> Vector (n+m) a -> (Vector n a, Vector m a)
+splitAt' :: forall n m a p. (KnownNat n, KnownNat m, Storable a)
+         => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
 
@@ -431,8 +431,8 @@ replicate = V.replicate
 
 -- | /O(n)/ Construct a vector with the same element in each position where the
 -- length is given explicitly as a 'Proxy' argument.
-replicate' :: forall n a. (KnownNat n, Storable a)
-           => Proxy n -> a -> Vector n a
+replicate' :: forall n a p. (KnownNat n, Storable a)
+           => p n -> a -> Vector n a
 replicate' = V.replicate'
 {-# inline replicate' #-}
 
@@ -445,8 +445,8 @@ generate = V.generate
 
 -- | /O(n)/ construct a vector of the given length by applying the function to
 -- each index where the length is given explicitly as a 'Proxy' argument.
-generate' :: forall n a. (KnownNat n, Storable a)
-          => Proxy n -> (Int -> a) -> Vector n a
+generate' :: forall n a p. (KnownNat n, Storable a)
+          => p n -> (Int -> a) -> Vector n a
 generate' = V.generate'
 {-# inline generate' #-}
 
@@ -469,8 +469,8 @@ iterateN = V.iterateN
 
 -- | /O(n)/ Apply function n times to value. Zeroth element is original value.
 -- The length is given explicitly as a 'Proxy' argument.
-iterateN' :: forall n a. (KnownNat n, Storable a)
-          => Proxy n -> (a -> a) -> a -> Vector n a
+iterateN' :: forall n a p. (KnownNat n, Storable a)
+          => p n -> (a -> a) -> a -> Vector n a
 iterateN' = V.iterateN'
 {-# inline iterateN' #-}
 
@@ -487,8 +487,8 @@ replicateM = V.replicateM
 
 -- | /O(n)/ Execute the monadic action @n@ times and store the results in a
 -- vector where @n@ is given explicitly as a 'Proxy' argument.
-replicateM' :: forall n m a. (KnownNat n, Storable a, Monad m)
-            => Proxy n -> m a -> m (Vector n a)
+replicateM' :: forall n m a p. (KnownNat n, Storable a, Monad m)
+            => p n -> m a -> m (Vector n a)
 replicateM' = V.replicateM'
 {-# inline replicateM' #-}
 
@@ -501,8 +501,8 @@ generateM = V.generateM
 
 -- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
 -- each index where n is given explicitly as a 'Proxy' argument.
-generateM' :: forall n m a. (KnownNat n, Storable a, Monad m)
-           => Proxy n -> (Int -> m a) -> m (Vector n a)
+generateM' :: forall n m a p. (KnownNat n, Storable a, Monad m)
+           => p n -> (Int -> m a) -> m (Vector n a)
 generateM' = V.generateM'
 {-# inline generateM' #-}
 
@@ -531,8 +531,8 @@ unfoldrN = V.unfoldrN
 -- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to the a seed. The length, @n@, is given explicitly
 -- as a 'Proxy' argument.
-unfoldrN' :: forall n a b. (KnownNat n, Storable a)
-          => Proxy n -> (b -> (a, b)) -> b -> Vector n a
+unfoldrN' :: forall n a b p. (KnownNat n, Storable a)
+          => p n -> (b -> (a, b)) -> b -> Vector n a
 unfoldrN' = V.unfoldrN'
 {-# inline unfoldrN' #-}
 
@@ -549,8 +549,8 @@ enumFromN = V.enumFromN
 
 -- | /O(n)/ Yield a vector of length @n@ containing the values @x@, @x+1@
 -- etc. The length, @n@, is given explicitly as a 'Proxy' argument.
-enumFromN' :: forall n a. (KnownNat n, Storable a, Num a)
-           => a -> Proxy n -> Vector n a
+enumFromN' :: forall n a p. (KnownNat n, Storable a, Num a)
+           => a -> p n -> Vector n a
 enumFromN' = V.enumFromN'
 {-# inline enumFromN' #-}
 
@@ -563,8 +563,8 @@ enumFromStepN = V.enumFromStepN
 
 -- | /O(n)/ Yield a vector of the given length containing the values @x@, @x+y@,
 -- @x+y+y@ etc. The length, @n@, is given explicitly as a 'Proxy' argument.
-enumFromStepN' :: forall n a. (KnownNat n, Storable a, Num a)
-               => a -> a -> Proxy n -> Vector n a
+enumFromStepN' :: forall n a p. (KnownNat n, Storable a, Num a)
+               => a -> a -> p n -> Vector n a
 enumFromStepN' = V.enumFromStepN'
 {-# inline enumFromStepN' #-}
 
@@ -1468,8 +1468,8 @@ fromListN = V.fromListN
 
 -- | /O(n)/ Convert the first @n@ elements of a list to a vector. The length of
 -- the resultant vector is given explicitly as a 'Proxy' argument.
-fromListN' :: forall n a. (Storable a, KnownNat n)
-           => Proxy n -> [a] -> Maybe (Vector n a)
+fromListN' :: forall n a p. (Storable a, KnownNat n)
+           => p n -> [a] -> Maybe (Vector n a)
 fromListN' = V.fromListN'
 {-# inline fromListN' #-}
 


### PR DESCRIPTION
Noticed that there are functions that take `Proxy n` in this library in order to let the user provide a type variable `n`.  By Haskell convention, functions like this (like the functions in `GHC.TypeLits`) usually take `forall p. p n`, so that the user can provide `Proxy` if desired, or any other type they might have on them.  This PR makes these changes, in a way that should be backwards-compatible in (almost all) situations.