### PR TITLE
Num/Fractional/Floating instances for sized vectors

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -1608,3 +1608,37 @@ withVectorUnsafe :: forall a b v w (n :: Nat). (VG.Vector v a, VG.Vector w b)
                  => (v a -> w b) -> Vector v n a -> Vector w n b
 withVectorUnsafe f (Vector v) = Vector (f v)
 {-# inline withVectorUnsafe #-}
+
+instance (VG.Vector v a, Num a, KnownNat n) => Num (Vector v n a) where
+    (+)         = zipWith (+)
+    (-)         = zipWith (-)
+    (*)         = zipWith (*)
+    negate      = map negate
+    abs         = map abs
+    signum      = map signum
+    fromInteger = replicate . fromInteger
+
+instance (VG.Vector v a, Fractional a, KnownNat n) => Fractional (Vector v n a) where
+    (/)          = zipWith (/)
+    recip        = map recip
+    fromRational = replicate . fromRational
+
+instance (VG.Vector v a, Floating a, KnownNat n) => Floating (Vector v n a) where
+    pi      = replicate pi
+    exp     = map exp
+    log     = map log
+    sqrt    = map sqrt
+    (**)    = zipWith (**)
+    logBase = zipWith logBase
+    sin     = map sin
+    cos     = map cos
+    tan     = map tan
+    asin    = map asin
+    acos    = map acos
+    atan    = map atan
+    sinh    = map sinh
+    cosh    = map cosh
+    tanh    = map tanh
+    asinh   = map asinh
+    acosh   = map acosh
+    atanh   = map atanh


### PR DESCRIPTION
Not sure if this would belong here, but there are some useful numeric instances for sized vectors.  They're "zippy" instances, so addition is element-wise addition, negate is negating every element, etc.

These have been convenient for me (for automatically deriving Num instances for things that use vectors) but since the actual `vector` API doesn't export a Num instance, it might make sense for this package to now have one either.

But there is a difference...for normal unsized `vector`s, their Num instances would be the cartesian product instance, so `(+)`/`(-)`/etc. might produce huge vectors of unbounded size, which might be why the original `vector` package doesn't have this instance.  This problem is not an issue for the instance here, since all numerical operations will yield vectors of the same size.