### PR TITLE
More functions using 'Finite' instead of 'Int'

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -231,6 +231,7 @@ import qualified Data.Vector.Generic as VG
 import qualified Data.Vector as Boxed
 import GHC.Generics (Generic)
 import GHC.TypeLits
+import Data.Bifunctor
 import Data.Finite
 import Data.Finite.Internal
 import Data.Proxy
@@ -859,9 +860,9 @@ unsafeBackpermute (Vector v) (Vector is) = Vector (VG.unsafeBackpermute v is)
 --
 
 -- | /O(n)/ Pair each element in a vector with its index
-indexed :: (VG.Vector v a, VG.Vector v (Int,a))
-        => Vector v n a -> Vector v n (Int,a)
-indexed (Vector v) = Vector (VG.indexed v)
+indexed :: (VG.Vector v a, VG.Vector v (Int, a), VG.Vector v (Finite n,a))
+        => Vector v n a -> Vector v n (Finite n,a)
+indexed (Vector v) = Vector ((VG.map . first) (Finite . fromIntegral) $ VG.indexed v)
 {-# inline indexed #-}
 
 --

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -680,10 +680,10 @@ force (Vector v) = Vector (VG.force v)
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
 --
 (//) :: (VG.Vector v a)
-     => Vector v m a -- ^ initial vector (of length @m@)
-     -> [(Int, a)]   -- ^ list of index/value pairs (of length @n@)
+     => Vector v m a    -- ^ initial vector (of length @m@)
+     -> [(Finite m, a)] -- ^ list of index/value pairs (of length @n@)
      -> Vector v m a
-Vector v // us = Vector (v VG.// us)
+Vector v // us = Vector (v VG.// (fmap . first) (fromIntegral . getFinite) us)
 {-# inline (//) #-}
 
 -- | /O(m+n)/ For each pair @(i,a)@ from the vector of index/value pairs,

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -814,7 +814,7 @@ map = V.map
 {-# inline map #-}
 
 -- | /O(n)/ Apply a function to every element of a vector and its index
-imap :: (Int -> a -> b) -> Vector n a -> Vector n b
+imap :: (Finite n -> a -> b) -> Vector n a -> Vector n b
 imap = V.imap
 {-# inline imap #-}
 
@@ -836,7 +836,7 @@ mapM = V.mapM
 
 -- | /O(n)/ Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results
-imapM :: Monad m => (Int -> a -> m b) -> Vector n a -> m (Vector n b)
+imapM :: Monad m => (Finite n -> a -> m b) -> Vector n a -> m (Vector n b)
 imapM = V.imapM
 {-# inline imapM #-}
 
@@ -848,7 +848,7 @@ mapM_ = V.mapM_
 
 -- | /O(n)/ Apply the monadic action to every element of a vector and its
 -- index, ignoring the results
-imapM_ :: Monad m => (Int -> a -> m b) -> Vector n a -> m ()
+imapM_ :: Monad m => (Finite n -> a -> m b) -> Vector n a -> m ()
 imapM_ = V.imapM_
 {-# inline imapM_ #-}
 
@@ -910,14 +910,14 @@ zipWith6 = V.zipWith6
 
 -- | /O(n)/ Zip two vectors of the same length with a function that also takes
 -- the elements' indices).
-izipWith :: (Int -> a -> b -> c)
+izipWith :: (Finite n -> a -> b -> c)
          -> Vector n a
          -> Vector n b
          -> Vector n c
 izipWith = V.izipWith
 {-# inline izipWith #-}
 
-izipWith3 :: (Int -> a -> b -> c -> d)
+izipWith3 :: (Finite n -> a -> b -> c -> d)
           -> Vector n a
           -> Vector n b
           -> Vector n c
@@ -925,7 +925,7 @@ izipWith3 :: (Int -> a -> b -> c -> d)
 izipWith3 = V.izipWith3
 {-# inline izipWith3 #-}
 
-izipWith4 :: (Int -> a -> b -> c -> d -> e)
+izipWith4 :: (Finite n -> a -> b -> c -> d -> e)
           -> Vector n a
           -> Vector n b
           -> Vector n c
@@ -934,7 +934,7 @@ izipWith4 :: (Int -> a -> b -> c -> d -> e)
 izipWith4 = V.izipWith4
 {-# inline izipWith4 #-}
 
-izipWith5 :: (Int -> a -> b -> c -> d -> e -> f)
+izipWith5 :: (Finite n -> a -> b -> c -> d -> e -> f)
           -> Vector n a
           -> Vector n b
           -> Vector n c
@@ -944,7 +944,7 @@ izipWith5 :: (Int -> a -> b -> c -> d -> e -> f)
 izipWith5 = V.izipWith5
 {-# inline izipWith5 #-}
 
-izipWith6 :: (Int -> a -> b -> c -> d -> e -> f -> g)
+izipWith6 :: (Finite n -> a -> b -> c -> d -> e -> f -> g)
           -> Vector n a
           -> Vector n b
           -> Vector n c
@@ -1005,7 +1005,7 @@ zipWithM = V.zipWithM
 -- | /O(n)/ Zip the two vectors with a monadic action that also takes the
 -- element index and yield a vector of results
 izipWithM :: Monad m
-         => (Int -> a -> b -> m c) -> Vector n a -> Vector n b -> m (Vector n c)
+         => (Finite n -> a -> b -> m c) -> Vector n a -> Vector n b -> m (Vector n c)
 izipWithM = V.izipWithM
 {-# inline izipWithM #-}
 
@@ -1018,7 +1018,7 @@ zipWithM_ = V.zipWithM_
 -- | /O(n)/ Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results
 izipWithM_ :: Monad m
-           => (Int -> a -> b -> m c) -> Vector n a -> Vector n b -> m ()
+           => (Finite n -> a -> b -> m c) -> Vector n a -> Vector n b -> m ()
 izipWithM_ = V.izipWithM_
 {-# inline izipWithM_ #-}
 
@@ -1075,14 +1075,14 @@ find = V.find
 
 -- | /O(n)/ Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
-findIndex :: (a -> Bool) -> Vector n a -> Maybe Int
+findIndex :: (a -> Bool) -> Vector n a -> Maybe (Finite n)
 findIndex = V.findIndex
 {-# inline findIndex #-}
 
 -- | /O(n)/ Yield 'Just' the index of the first occurence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
-elemIndex :: (Eq a) => a -> Vector n a -> Maybe Int
+elemIndex :: (Eq a) => a -> Vector n a -> Maybe (Finite n)
 elemIndex = V.elemIndex
 {-# inline elemIndex #-}
 
@@ -1131,24 +1131,24 @@ foldr1' = V.foldr1'
 {-# inline foldr1' #-}
 
 -- | /O(n)/ Left fold (function applied to each element and its index)
-ifoldl :: (a -> Int -> b -> a) -> a -> Vector n b -> a
+ifoldl :: (a -> Finite n -> b -> a) -> a -> Vector n b -> a
 ifoldl = V.ifoldl
 {-# inline ifoldl #-}
 
 -- | /O(n)/ Left fold with strict accumulator (function applied to each element
 -- and its index)
-ifoldl' :: (a -> Int -> b -> a) -> a -> Vector n b -> a
+ifoldl' :: (a -> Finite n -> b -> a) -> a -> Vector n b -> a
 ifoldl' = V.ifoldl'
 {-# inline ifoldl' #-}
 
 -- | /O(n)/ Right fold (function applied to each element and its index)
-ifoldr :: (Int -> a -> b -> b) -> b -> Vector n a -> b
+ifoldr :: (Finite n -> a -> b -> b) -> b -> Vector n a -> b
 ifoldr = V.ifoldr
 {-# inline ifoldr #-}
 
 -- | /O(n)/ Right fold with strict accumulator (function applied to each
 -- element and its index)
-ifoldr' :: (Int -> a -> b -> b) -> b -> Vector n a -> b
+ifoldr' :: (Finite n -> a -> b -> b) -> b -> Vector n a -> b
 ifoldr' = V.ifoldr'
 {-# inline ifoldr' #-}
 
@@ -1209,26 +1209,26 @@ minimumBy = V.minimumBy
 {-# inline minimumBy #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector.
-maxIndex :: (Ord a, KnownNat n) => Vector (n+1) a -> Int
+maxIndex :: (Ord a, KnownNat n) => Vector (n+1) a -> Finite (n + 1)
 maxIndex = V.maxIndex
 {-# inline maxIndex #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector
 -- according to the given comparison function.
 maxIndexBy :: KnownNat n
-           => (a -> a -> Ordering) -> Vector (n+1) a -> Int
+           => (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
 maxIndexBy = V.maxIndexBy
 {-# inline maxIndexBy #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector.
-minIndex :: (Ord a, KnownNat n) => Vector (n+1) a -> Int
+minIndex :: (Ord a, KnownNat n) => Vector (n+1) a -> Finite (n + 1)
 minIndex = V.minIndex
 {-# inline minIndex #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector
 -- according to the given comparison function.
 minIndexBy :: KnownNat n
-           => (a -> a -> Ordering) -> Vector (n+1) a -> Int
+           => (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
 minIndexBy = V.minIndexBy
 {-# inline minIndexBy #-}
 
@@ -1240,7 +1240,7 @@ foldM = V.foldM
 {-# inline foldM #-}
 
 -- | /O(n)/ Monadic fold (action applied to each element and its index)
-ifoldM :: Monad m => (a -> Int -> b -> m a) -> a -> Vector n b -> m a
+ifoldM :: Monad m => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m a
 ifoldM = V.ifoldM
 {-# inline ifoldM #-}
 
@@ -1258,7 +1258,7 @@ foldM' = V.foldM'
 -- | /O(n)/ Monadic fold with strict accumulator (action applied to each
 -- element and its index)
 ifoldM' :: Monad m
-        => (a -> Int -> b -> m a) -> a -> Vector n b -> m a
+        => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m a
 ifoldM' = V.ifoldM'
 {-# inline ifoldM' #-}
 
@@ -1277,7 +1277,7 @@ foldM_ = V.foldM_
 -- | /O(n)/ Monadic fold that discards the result (action applied to
 -- each element and its index)
 ifoldM_ :: Monad m
-        => (a -> Int -> b -> m a) -> a -> Vector n b -> m ()
+        => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m ()
 ifoldM_ = V.ifoldM_
 {-# inline ifoldM_ #-}
 
@@ -1296,7 +1296,7 @@ foldM'_ = V.foldM'_
 -- | /O(n)/ Monadic fold with strict accumulator that discards the result
 -- (action applied to each element and its index)
 ifoldM'_ :: Monad m
-         => (a -> Int -> b -> m a) -> a -> Vector n b -> m ()
+         => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m ()
 ifoldM'_ = V.ifoldM'_
 {-# inline ifoldM'_ #-}
 

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -778,7 +778,7 @@ unsafeBackpermute = V.unsafeBackpermute
 --
 
 -- | /O(n)/ Pair each element in a vector with its index
-indexed :: Vector n a -> Vector n (Int,a)
+indexed :: Vector n a -> Vector n (Finite n,a)
 indexed = V.indexed
 {-# inline indexed #-}
 

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -612,8 +612,8 @@ force = V.force
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
 --
-(//) :: Vector m a -- ^ initial vector (of length @m@)
-     -> [(Int, a)]   -- ^ list of index/value pairs (of length @n@)
+(//) :: Vector m a      -- ^ initial vector (of length @m@)
+     -> [(Finite m, a)] -- ^ list of index/value pairs (of length @n@)
      -> Vector m a
 (//) = (V.//)
 {-# inline (//) #-}

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -55,7 +55,6 @@ module Data.Vector.Sized
   , replicate'
   , generate
   , generate'
-  , generate_
   , iterateN
   , iterateN'
     -- ** Monadic initialization
@@ -63,7 +62,6 @@ module Data.Vector.Sized
   , replicateM'
   , generateM
   , generateM'
-  , generateM_
     -- ** Unfolding
   , unfoldrN
   , unfoldrN'
@@ -454,26 +452,16 @@ replicate' = V.replicate'
 -- | /O(n)/ construct a vector of the given length by applying the function to
 -- each index where the length is inferred from the type.
 generate :: forall n a. KnownNat n
-         => (Int -> a) -> Vector n a
+         => (Finite n -> a) -> Vector n a
 generate = V.generate
 {-# inline generate #-}
 
 -- | /O(n)/ construct a vector of the given length by applying the function to
 -- each index where the length is given explicitly as a 'Proxy' argument.
 generate' :: forall n a p. KnownNat n
-          => p n -> (Int -> a) -> Vector n a
+          => p n -> (Finite n -> a) -> Vector n a
 generate' = V.generate'
 {-# inline generate' #-}
-
--- | /O(n)/ construct a vector of the given length by applying the function to
--- each index where the length is inferred from the type.
---
--- The function can expect a @'Finite' n@, meaning that its input will
--- always be between @0@ and @n - 1@.
-generate_ :: forall n a. KnownNat n
-          => (Finite n -> a) -> Vector n a
-generate_ = V.generate_
-{-# inline generate_ #-}
 
 -- | /O(n)/ Apply function n times to value. Zeroth element is original value.
 -- The length is inferred from the type.
@@ -510,24 +498,14 @@ replicateM' = V.replicateM'
 -- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
 -- each index where n is inferred from the type.
 generateM :: forall n m a. (KnownNat n, Monad m)
-          => (Int -> m a) -> m (Vector n a)
+          => (Finite n -> m a) -> m (Vector n a)
 generateM = V.generateM
 {-# inline generateM #-}
 
 -- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
--- each index where n is inferred from the type.
---
--- The function can expect a @'Finite' n@, meaning that its input will
--- always be between @0@ and @n - 1@.
-generateM_ :: forall n m a. (KnownNat n, Monad m)
-           => (Finite n -> m a) -> m (Vector n a)
-generateM_ = V.generateM_
-{-# inline generateM_ #-}
-
--- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
 -- each index where n is given explicitly as a 'Proxy' argument.
 generateM' :: forall n m a p. (KnownNat n, Monad m)
-           => p n -> (Int -> m a) -> m (Vector n a)
+           => p n -> (Finite n -> m a) -> m (Vector n a)
 generateM' = V.generateM'
 {-# inline generateM' #-}
 

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -54,7 +54,6 @@ module Data.Vector.Storable.Sized
   , replicate'
   , generate
   , generate'
-  , generate_
   , iterateN
   , iterateN'
     -- ** Monadic initialization
@@ -62,7 +61,6 @@ module Data.Vector.Storable.Sized
   , replicateM'
   , generateM
   , generateM'
-  , generateM_
     -- ** Unfolding
   , unfoldrN
   , unfoldrN'
@@ -461,26 +459,16 @@ replicate' = V.replicate'
 -- | /O(n)/ construct a vector of the given length by applying the function to
 -- each index where the length is inferred from the type.
 generate :: forall n a. (KnownNat n, Storable a)
-         => (Int -> a) -> Vector n a
+         => (Finite n -> a) -> Vector n a
 generate = V.generate
 {-# inline generate #-}
 
 -- | /O(n)/ construct a vector of the given length by applying the function to
 -- each index where the length is given explicitly as a 'Proxy' argument.
 generate' :: forall n a p. (KnownNat n, Storable a)
-          => p n -> (Int -> a) -> Vector n a
+          => p n -> (Finite n -> a) -> Vector n a
 generate' = V.generate'
 {-# inline generate' #-}
-
--- | /O(n)/ construct a vector of the given length by applying the function to
--- each index where the length is inferred from the type.
---
--- The function can expect a @'Finite' n@, meaning that its input will
--- always be between @0@ and @n - 1@.
-generate_ :: forall n a. (KnownNat n, Storable a)
-          => (Finite n -> a) -> Vector n a
-generate_ = V.generate_
-{-# inline generate_ #-}
 
 -- | /O(n)/ Apply function n times to value. Zeroth element is original value.
 -- The length is inferred from the type.
@@ -517,26 +505,16 @@ replicateM' = V.replicateM'
 -- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
 -- each index where n is inferred from the type.
 generateM :: forall n m a. (KnownNat n, Storable a, Monad m)
-          => (Int -> m a) -> m (Vector n a)
+          => (Finite n -> m a) -> m (Vector n a)
 generateM = V.generateM
 {-# inline generateM #-}
 
 -- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
 -- each index where n is given explicitly as a 'Proxy' argument.
 generateM' :: forall n m a p. (KnownNat n, Storable a, Monad m)
-           => p n -> (Int -> m a) -> m (Vector n a)
+           => p n -> (Finite n -> m a) -> m (Vector n a)
 generateM' = V.generateM'
 {-# inline generateM' #-}
-
--- | /O(n)/ Construct a vector of length @n@ by applying the monadic action to
--- each index where n is inferred from the type.
---
--- The function can expect a @'Finite' n@, meaning that its input will
--- always be between @0@ and @n - 1@.
-generateM_ :: forall n m a. (KnownNat n, Storable a, Monad m)
-           => (Finite n -> m a) -> m (Vector n a)
-generateM_ = V.generateM_
-{-# inline generateM_ #-}
 
 --
 -- ** Unfolding

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -841,7 +841,7 @@ map = V.map
 
 -- | /O(n)/ Apply a function to every element of a vector and its index
 imap :: (Storable a, Storable b)
-     => (Int -> a -> b) -> Vector n a -> Vector n b
+     => (Finite n -> a -> b) -> Vector n a -> Vector n b
 imap = V.imap
 {-# inline imap #-}
 
@@ -866,7 +866,7 @@ mapM = V.mapM
 -- | /O(n)/ Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results
 imapM :: (Monad m, Storable a, Storable b)
-      => (Int -> a -> m b) -> Vector n a -> m (Vector n b)
+      => (Finite n -> a -> m b) -> Vector n a -> m (Vector n b)
 imapM = V.imapM
 {-# inline imapM #-}
 
@@ -878,7 +878,7 @@ mapM_ = V.mapM_
 
 -- | /O(n)/ Apply the monadic action to every element of a vector and its
 -- index, ignoring the results
-imapM_ :: (Monad m, Storable a) => (Int -> a -> m b) -> Vector n a -> m ()
+imapM_ :: (Monad m, Storable a) => (Finite n -> a -> m b) -> Vector n a -> m ()
 imapM_ = V.imapM_
 {-# inline imapM_ #-}
 
@@ -947,7 +947,7 @@ zipWith6 = V.zipWith6
 -- | /O(n)/ Zip two vectors of the same length with a function that also takes
 -- the elements' indices).
 izipWith :: (Storable a,Storable b,Storable c)
-         => (Int -> a -> b -> c)
+         => (Finite n -> a -> b -> c)
          -> Vector n a
          -> Vector n b
          -> Vector n c
@@ -955,7 +955,7 @@ izipWith = V.izipWith
 {-# inline izipWith #-}
 
 izipWith3 :: (Storable a,Storable b,Storable c,Storable d)
-          => (Int -> a -> b -> c -> d)
+          => (Finite n -> a -> b -> c -> d)
           -> Vector n a
           -> Vector n b
           -> Vector n c
@@ -964,7 +964,7 @@ izipWith3 = V.izipWith3
 {-# inline izipWith3 #-}
 
 izipWith4 :: (Storable a,Storable b,Storable c,Storable d,Storable e)
-          => (Int -> a -> b -> c -> d -> e)
+          => (Finite n -> a -> b -> c -> d -> e)
           -> Vector n a
           -> Vector n b
           -> Vector n c
@@ -974,7 +974,7 @@ izipWith4 = V.izipWith4
 {-# inline izipWith4 #-}
 
 izipWith5 :: (Storable a,Storable b,Storable c,Storable d,Storable e,Storable f)
-          => (Int -> a -> b -> c -> d -> e -> f)
+          => (Finite n -> a -> b -> c -> d -> e -> f)
           -> Vector n a
           -> Vector n b
           -> Vector n c
@@ -985,7 +985,7 @@ izipWith5 = V.izipWith5
 {-# inline izipWith5 #-}
 
 izipWith6 :: (Storable a,Storable b,Storable c,Storable d,Storable e,Storable f,Storable g)
-          => (Int -> a -> b -> c -> d -> e -> f -> g)
+          => (Finite n -> a -> b -> c -> d -> e -> f -> g)
           -> Vector n a
           -> Vector n b
           -> Vector n c
@@ -1051,7 +1051,7 @@ zipWithM = V.zipWithM
 -- | /O(n)/ Zip the two vectors with a monadic action that also takes the
 -- element index and yield a vector of results
 izipWithM :: (Monad m, Storable a, Storable b, Storable c)
-         => (Int -> a -> b -> m c) -> Vector n a -> Vector n b -> m (Vector n c)
+         => (Finite n -> a -> b -> m c) -> Vector n a -> Vector n b -> m (Vector n c)
 izipWithM = V.izipWithM
 {-# inline izipWithM #-}
 
@@ -1064,7 +1064,7 @@ zipWithM_ = V.zipWithM_
 -- | /O(n)/ Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results
 izipWithM_ :: (Monad m, Storable a, Storable b)
-           => (Int -> a -> b -> m c) -> Vector n a -> Vector n b -> m ()
+           => (Finite n -> a -> b -> m c) -> Vector n a -> Vector n b -> m ()
 izipWithM_ = V.izipWithM_
 {-# inline izipWithM_ #-}
 
@@ -1129,14 +1129,14 @@ find = V.find
 
 -- | /O(n)/ Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
-findIndex :: Storable a => (a -> Bool) -> Vector n a -> Maybe Int
+findIndex :: Storable a => (a -> Bool) -> Vector n a -> Maybe (Finite n)
 findIndex = V.findIndex
 {-# inline findIndex #-}
 
 -- | /O(n)/ Yield 'Just' the index of the first occurence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
-elemIndex :: (Storable a, Eq a) => a -> Vector n a -> Maybe Int
+elemIndex :: (Storable a, Eq a) => a -> Vector n a -> Maybe (Finite n)
 elemIndex = V.elemIndex
 {-# inline elemIndex #-}
 
@@ -1185,24 +1185,24 @@ foldr1' = V.foldr1'
 {-# inline foldr1' #-}
 
 -- | /O(n)/ Left fold (function applied to each element and its index)
-ifoldl :: Storable b => (a -> Int -> b -> a) -> a -> Vector n b -> a
+ifoldl :: Storable b => (a -> Finite n -> b -> a) -> a -> Vector n b -> a
 ifoldl = V.ifoldl
 {-# inline ifoldl #-}
 
 -- | /O(n)/ Left fold with strict accumulator (function applied to each element
 -- and its index)
-ifoldl' :: Storable b => (a -> Int -> b -> a) -> a -> Vector n b -> a
+ifoldl' :: Storable b => (a -> Finite n -> b -> a) -> a -> Vector n b -> a
 ifoldl' = V.ifoldl'
 {-# inline ifoldl' #-}
 
 -- | /O(n)/ Right fold (function applied to each element and its index)
-ifoldr :: Storable a => (Int -> a -> b -> b) -> b -> Vector n a -> b
+ifoldr :: Storable a => (Finite n -> a -> b -> b) -> b -> Vector n a -> b
 ifoldr = V.ifoldr
 {-# inline ifoldr #-}
 
 -- | /O(n)/ Right fold with strict accumulator (function applied to each
 -- element and its index)
-ifoldr' :: Storable a => (Int -> a -> b -> b) -> b -> Vector n a -> b
+ifoldr' :: Storable a => (Finite n -> a -> b -> b) -> b -> Vector n a -> b
 ifoldr' = V.ifoldr'
 {-# inline ifoldr' #-}
 
@@ -1263,26 +1263,26 @@ minimumBy = V.minimumBy
 {-# inline minimumBy #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector.
-maxIndex :: (Storable a, Ord a, KnownNat n) => Vector (n+1) a -> Int
+maxIndex :: (Storable a, Ord a, KnownNat n) => Vector (n+1) a -> Finite (n + 1)
 maxIndex = V.maxIndex
 {-# inline maxIndex #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector
 -- according to the given comparison function.
 maxIndexBy :: (Storable a, KnownNat n)
-           => (a -> a -> Ordering) -> Vector (n+1) a -> Int
+           => (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
 maxIndexBy = V.maxIndexBy
 {-# inline maxIndexBy #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector.
-minIndex :: (Storable a, Ord a, KnownNat n) => Vector (n+1) a -> Int
+minIndex :: (Storable a, Ord a, KnownNat n) => Vector (n+1) a -> Finite (n + 1)
 minIndex = V.minIndex
 {-# inline minIndex #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector
 -- according to the given comparison function.
 minIndexBy :: (Storable a, KnownNat n)
-           => (a -> a -> Ordering) -> Vector (n+1) a -> Int
+           => (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
 minIndexBy = V.minIndexBy
 {-# inline minIndexBy #-}
 
@@ -1294,7 +1294,7 @@ foldM = V.foldM
 {-# inline foldM #-}
 
 -- | /O(n)/ Monadic fold (action applied to each element and its index)
-ifoldM :: (Monad m, Storable b) => (a -> Int -> b -> m a) -> a -> Vector n b -> m a
+ifoldM :: (Monad m, Storable b) => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m a
 ifoldM = V.ifoldM
 {-# inline ifoldM #-}
 
@@ -1312,7 +1312,7 @@ foldM' = V.foldM'
 -- | /O(n)/ Monadic fold with strict accumulator (action applied to each
 -- element and its index)
 ifoldM' :: (Monad m, Storable b)
-        => (a -> Int -> b -> m a) -> a -> Vector n b -> m a
+        => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m a
 ifoldM' = V.ifoldM'
 {-# inline ifoldM' #-}
 
@@ -1331,7 +1331,7 @@ foldM_ = V.foldM_
 -- | /O(n)/ Monadic fold that discards the result (action applied to
 -- each element and its index)
 ifoldM_ :: (Monad m, Storable b)
-        => (a -> Int -> b -> m a) -> a -> Vector n b -> m ()
+        => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m ()
 ifoldM_ = V.ifoldM_
 {-# inline ifoldM_ #-}
 
@@ -1350,7 +1350,7 @@ foldM'_ = V.foldM'_
 -- | /O(n)/ Monadic fold with strict accumulator that discards the result
 -- (action applied to each element and its index)
 ifoldM'_ :: (Monad m, Storable b)
-         => (a -> Int -> b -> m a) -> a -> Vector n b -> m ()
+         => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m ()
 ifoldM'_ = V.ifoldM'_
 {-# inline ifoldM'_ #-}
 

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -802,8 +802,8 @@ unsafeBackpermute = V.unsafeBackpermute
 --
 
 -- | /O(n)/ Pair each element in a vector with its index
-indexed :: (Storable a, Storable (Int,a))
-        => Vector n a -> Vector n (Int,a)
+indexed :: (Storable a, Storable (Int, a), Storable (Finite n, a))
+        => Vector n a -> Vector n (Finite n,a)
 indexed = V.indexed
 {-# inline indexed #-}
 

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -623,8 +623,8 @@ force = V.force
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
 --
 (//) :: (Storable a)
-     => Vector m a -- ^ initial vector (of length @m@)
-     -> [(Int, a)]   -- ^ list of index/value pairs (of length @n@)
+     => Vector m a      -- ^ initial vector (of length @m@)
+     -> [(Finite m, a)] -- ^ list of index/value pairs (of length @n@)
      -> Vector m a
 (//) = (V.//)
 {-# inline (//) #-}


### PR DESCRIPTION
I noticed that a lot more functions can be rewritten to use `Finite` instead of `Int`, so I changed some of them here.  Some issues:

1. This *replaces* the current functions, so is backwards-incompatible.  The alternative is to have some sort of naming convention for *all* of the dozen+ functions, which would make the API considerably messier.
2. This only replaces the functions for which the `Int` is in the *positive* position of the functions (that is, for functions that return Int, or higher-order functions taking functions that expect Int.  Essentially, functions where the library generates an `Int`, instead of using one given by the user).  So this excludes versions where the `Int` is in the negative position, like `update`/`accum` etc.  This is because `backpermute` and `update` and `update_` also *take* vectors of `Int`s, but this isn't possible for `Finite`, since `Finite` (a wrapper over `Integer`) has no possible `Storable` instance.

    However, using `Finite` in the negative position does benefit the implementation of the library.  Like in the case for `index`, if we swap `Int` for `Finite` in the negative position, we can always use unsafe variants of the underlying implementation, and not check for bounds, making the library more performant.

    The only way I can see this working is if we decouple the definitions of update/accum for Storable and non-Storable vectors.  This lets non-storable variants take advantage of the performance gain, but it breaks the cleanliness of the library.  And of course, it's still backwards incompatible.

I understand that a giant backwards-incompatible PR like this one should not be taken lightly, so let me know if you think there's a better way to handle this, or if the changes are too much at this moment :)