### PR TITLE
Noted the addition of num instances in changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 ## [0.6.0.0] - 2017-06-07
 - Make ordering of additions in types be more consistent
 - Make slice more general
+- `Num`, `Fractional`, and `Floating` instances for vectors
 
 ## [0.5.1.0] - 2017-02-01
 - Loosen upper bound on `vector`


### PR DESCRIPTION
Just a small/silly thing, but I was updating version bounds for a package and I needed to figure out when this package added Num instances, but saw that it wasn't reflected in the changelog at the time, so I had to look at the docs for individual versions.  Admittedly this PR will not yield benefits for the vast majority of users, but just wanted to make the small change in case it is useful for anyone else :)