### PR TITLE
Describe difference between fixed-vector and vector-sized in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,12 +3,19 @@
 This package exports a newtype tagging the vectors from the
 [vector](https://hackage.haskell.org/package/vector) package with a type level
 natural representing their size.
-
 It also exports a few functions from vector appropriately retyped.
 
-This package is fairly similar to the
-[fixed-vector](https://hackage.haskell.org/package/fixed-vector) package. The
-difference is that fixed-vector uses Peano naturals to represent the size tag
-on the vectors and this package uses typelits.
+This package is fairly similar to
+the [fixed-vector](https://hackage.haskell.org/package/fixed-vector) package.
+While both provide vectors of statically know length they use completely
+different implementation with different tradeoffs. `vector-sized` is a newtype
+wrapper over `vector` thus it's able to handle vectors of arbitrary length but
+have to carry runtime representation of length which is significant memory
+overhead for small vectors. `fixed-vector` defines all functions as
+manipulations of Church-encoded product types (`∀r. (a→a→r) → r` for 2D vectors)
+so it can work for both arbitrary product types like `data V2 a = V2 a a` and
+opaque length-parametrized vectors provided by library. As consequence of
+implementation it can't handle vectors larger than tens of elements.
+
 
 The initial code for this package was written by @bgamari in a [PR for vulkan](https://github.com/expipiplus1/vulkan/pull/1)


### PR DESCRIPTION
Hi! Author of fixed-vector here

I updated readme to explain differences between fixed-vector and vector-sized. They have very different implementation and tradeoffs. Also use of Peano number in fixed-vector is more out of necessety. There is no support for working with type nats inductively and I wasn't able to find any reasonable workaround so far