### PR TITLE
Semigroup and Read instances

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -241,6 +241,9 @@ import Foreign.Storable
 import Data.Data
 import Foreign.Ptr (castPtr)
 import Data.Semigroup
+import Text.Read.Lex
+import Text.ParserCombinators.ReadPrec
+import GHC.Read
 import Prelude hiding ( length, null,
                         replicate, (++), concat,
                         head, last,
@@ -261,6 +264,12 @@ newtype Vector v (n :: Nat) a = Vector (v a)
   deriving ( Show, Eq, Ord, Functor, Foldable, Traversable, NFData, Generic
            , Data, Typeable
            )
+
+instance (KnownNat n, VG.Vector v a, Read (v a)) => Read (Vector v n a) where
+  readPrec = parens $ prec 10 $ do
+      expectP (Ident "Vector")
+      vec <- readPrec
+      if VG.length vec == (fromInteger $ natVal (Proxy :: Proxy n)) then return $ Vector vec else pfail
 
 -- | Any sized vector containing storable elements is itself storable.
 instance (KnownNat n, Storable a, VG.Vector v a)

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -286,8 +286,8 @@ instance (KnownNat n, Storable a, VG.Vector v a)
 instance KnownNat n => Applicative (Vector Boxed.Vector n) where
   pure = replicate
   (<*>) = zipWith ($)
-  _ *> r = r
-  l <* _ = l
+  (*>) = seq
+  (<*) = flip seq
 
 -- | The 'Semigroup' instance for sized vectors does not have the same
 -- behaviour as the 'Semigroup' instance for the unsized vectors found in the
@@ -314,7 +314,7 @@ instance (Monoid m, VG.Vector v m, KnownNat n) => Monoid (Vector v n m) where
 -- empty vectors.
 instance {-# OVERLAPPING #-} (VG.Vector v m) => Monoid (Vector v 0 m) where
   mempty = empty
-  _empty1 `mappend` _empty2 = empty
+  l `mappend` r = l `seq` r `seq` empty
 
 -- | /O(1)/ Yield the length of the vector as an 'Int'.
 length :: forall v n a. (KnownNat n)

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -277,6 +277,8 @@ instance (KnownNat n, Storable a, VG.Vector v a)
 instance KnownNat n => Applicative (Vector Boxed.Vector n) where
   pure = replicate
   (<*>) = zipWith ($)
+  _ *> r = r
+  l <* _ = l
 
 -- | The 'Semigroup' instance for sized vectors does not have the same
 -- behaviour as the 'Semigroup' instance for the unsized vectors found in the


### PR DESCRIPTION
```haskell
ghci> :set -XTypeApplications -XDataKinds
ghci> :load Data.Vector.Sized
ghci> -- Semigroup
ghci> import Data.Semigroup
ghci> let rep5 :: {- no KnownNat -} Semigroup g => Vector n g -> Vector n g; rep5 = stimes 5
ghci> getSum <$> rep5 (generate @5 Sum)
Vector [0,5,10,15,20]
ghci> -- Read
ghci> vec = show it
ghci> read @(Vector 5 Int) vec
Vector [0,5,10,15,20]
ghci> read @(Vector 5 ()) vec
Vector *** Exception: Prelude.read: no parse
ghci> read @(Vector 4 Int) vec
Vector *** Exception: Prelude.read: no parse
```

Also, the `(<*)` and `(*>)` for this type simply end up returning one of the two arguments, but the default definitions construct new vectors even though it is unnecessary. I threw those in for good measure.