### PR TITLE
Add a knownLength function

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -296,7 +296,7 @@ instance {-# OVERLAPPING #-} (VG.Vector v m) => Monoid (Vector v 0 m) where
 -- | /O(1)/ Yield the length of the vector as an 'Int'. This is more like
 -- 'natVal' than 'Data.Vector.length', extracting the value from the 'KnownNat'
 -- instance and not looking at the vector itself.
-length :: forall v n a. (KnownNat n)
+length :: forall v n a. KnownNat n
        => Vector v n a -> Int
 length _ = fromInteger (natVal (Proxy :: Proxy n))
 {-# inline length #-}
@@ -304,8 +304,8 @@ length _ = fromInteger (natVal (Proxy :: Proxy n))
 -- | /O(1)/ Yield the length of the vector as a 'Proxy'. This function
 -- doesn't /do/ anything; it merely allows the size parameter of the vector
 -- to be passed around as a 'Proxy'.
-length' :: forall v n a. (KnownNat n)
-        => Vector v n a -> Proxy n
+length' :: forall v n a.
+           Vector v n a -> Proxy n
 length' _ = Proxy
 {-# inline length' #-}
 

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -261,8 +261,8 @@ length = V.length
 -- | /O(1)/ Yield the length of the vector as a 'Proxy'. This function
 -- doesn't /do/ anything; it merely allows the size parameter of the vector
 -- to be passed around as a 'Proxy'.
-length' :: forall n a. KnownNat n
-        => Vector n a -> Proxy n
+length' :: forall n a.
+           Vector n a -> Proxy n
 length' = V.length'
 {-# inline length' #-}
 

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -250,13 +250,17 @@ import Prelude hiding ( length, null,
 -- 'Data.Vector'
 type Vector = V.Vector VU.Vector
 
--- | /O(1)/ Yield the length of the vector as an 'Int'.
+-- | /O(1)/ Yield the length of the vector as an 'Int'. This is more like
+-- 'natVal' than 'Data.Vector.length', extracting the value from the 'KnownNat'
+-- instance and not looking at the vector itself.
 length :: forall n a. KnownNat n
        => Vector n a -> Int
 length = V.length
 {-# inline length #-}
 
--- | /O(1)/ Yield the length of the vector as a 'Proxy'.
+-- | /O(1)/ Yield the length of the vector as a 'Proxy'. This function
+-- doesn't /do/ anything; it merely allows the size parameter of the vector
+-- to be passed around as a 'Proxy'.
 length' :: forall n a. KnownNat n
         => Vector n a -> Proxy n
 length' = V.length'
@@ -265,13 +269,17 @@ length' = V.length'
 -- | /O(1)/ Reveal a 'KnownNat' instance for a vector's length, determined
 -- at runtime.
 knownLength :: forall n a r.
-               Vector n a -> (KnownNat n => r) -> r
+               Vector n a -- ^ a vector of some (potentially unknown) length
+            -> (KnownNat n => r) -- ^ a value that depends on knowing the vector's length
+            -> r -- ^ the value computed with the length
 knownLength = V.knownLength
 
 -- | /O(1)/ Reveal a 'KnownNat' instance and 'Proxy' for a vector's length,
 -- determined at runtime.
 knownLength' :: forall n a r.
-                Vector n a -> (KnownNat n => Proxy n -> r) -> r
+                Vector n a -- ^ a vector of some (potentially unknown) length
+             -> (KnownNat n => Proxy n -> r) -- ^ a value that depends on knowing the vector's length, which is given as a 'Proxy'
+             -> r -- ^ the value computed with the length
 knownLength' = V.knownLength'
 
 -- | /O(1)/ Safe indexing using a 'Finite'.

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -24,6 +24,8 @@ module Data.Vector.Sized
    -- ** Length information
   , length
   , length'
+  , knownLength
+  , knownLength'
     -- ** Indexing
   , index
   , index'
@@ -259,6 +261,18 @@ length' :: forall n a. KnownNat n
         => Vector n a -> Proxy n
 length' = V.length'
 {-# inline length' #-}
+
+-- | /O(1)/ Reveal a 'KnownNat' instance for a vector's length, determined
+-- at runtime.
+knownLength :: forall n a r.
+               Vector n a -> (KnownNat n => r) -> r
+knownLength = V.knownLength
+
+-- | /O(1)/ Reveal a 'KnownNat' instance and 'Proxy' for a vector's length,
+-- determined at runtime.
+knownLength' :: forall n a r.
+                Vector n a -> (KnownNat n => Proxy n -> r) -> r
+knownLength' = V.knownLength'
 
 -- | /O(1)/ Safe indexing using a 'Finite'.
 index :: forall n a. KnownNat n

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -23,6 +23,8 @@ module Data.Vector.Storable.Sized
    -- ** Length information
   , length
   , length'
+  , knownLength
+  , knownLength'
     -- ** Indexing
   , index
   , index'
@@ -259,6 +261,18 @@ length' :: forall n a. (KnownNat n)
         => Vector n a -> Proxy n
 length' = V.length'
 {-# inline length' #-}
+
+-- | /O(1)/ Reveal a 'KnownNat' instance for a vector's length, determined
+-- at runtime.
+knownLength :: forall n a r. Storable a
+            => Vector n a -> (KnownNat n => r) -> r
+knownLength = V.knownLength
+
+-- | /O(1)/ Reveal a 'KnownNat' instance and 'Proxy' for a vector's length,
+-- determined at runtime.
+knownLength' :: forall n a r. Storable a
+             => Vector n a -> (KnownNat n => Proxy n -> r) -> r
+knownLength' = V.knownLength'
 
 -- | /O(1)/ Safe indexing using a 'Finite'.
 index :: forall n a. (KnownNat n, Storable a)

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -250,13 +250,17 @@ import Prelude hiding ( length, null,
 -- 'Data.Vector.Storable'
 type Vector = V.Vector VS.Vector
 
--- | /O(1)/ Yield the length of the vector as an 'Int'.
+-- | /O(1)/ Yield the length of the vector as an 'Int'. This is more like
+-- 'natVal' than 'Data.Vector.length', extracting the value from the 'KnownNat'
+-- instance and not looking at the vector itself.
 length :: forall n a. (KnownNat n)
        => Vector n a -> Int
 length = V.length
 {-# inline length #-}
 
--- | /O(1)/ Yield the length of the vector as a 'Proxy'.
+-- | /O(1)/ Yield the length of the vector as a 'Proxy'. This function
+-- doesn't /do/ anything; it merely allows the size parameter of the vector
+-- to be passed around as a 'Proxy'.
 length' :: forall n a. (KnownNat n)
         => Vector n a -> Proxy n
 length' = V.length'
@@ -265,13 +269,17 @@ length' = V.length'
 -- | /O(1)/ Reveal a 'KnownNat' instance for a vector's length, determined
 -- at runtime.
 knownLength :: forall n a r. Storable a
-            => Vector n a -> (KnownNat n => r) -> r
+            => Vector n a -- ^ a vector of some (potentially unknown) length
+            -> (KnownNat n => r) -- ^ a value that depends on knowing the vector's length
+            -> r -- ^ the value computed with the length
 knownLength = V.knownLength
 
 -- | /O(1)/ Reveal a 'KnownNat' instance and 'Proxy' for a vector's length,
 -- determined at runtime.
 knownLength' :: forall n a r. Storable a
-             => Vector n a -> (KnownNat n => Proxy n -> r) -> r
+             => Vector n a -- ^ a vector of some (potentially unknown) length
+             -> (KnownNat n => Proxy n -> r) -- ^ a value that depends on knowing the vector's length, which is given as a 'Proxy'
+             -> r -- ^ the value computed with the length
 knownLength' = V.knownLength'
 
 -- | /O(1)/ Safe indexing using a 'Finite'.

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -253,7 +253,7 @@ type Vector = V.Vector VS.Vector
 -- | /O(1)/ Yield the length of the vector as an 'Int'. This is more like
 -- 'natVal' than 'Data.Vector.length', extracting the value from the 'KnownNat'
 -- instance and not looking at the vector itself.
-length :: forall n a. (KnownNat n)
+length :: forall n a. KnownNat n
        => Vector n a -> Int
 length = V.length
 {-# inline length #-}
@@ -261,8 +261,8 @@ length = V.length
 -- | /O(1)/ Yield the length of the vector as a 'Proxy'. This function
 -- doesn't /do/ anything; it merely allows the size parameter of the vector
 -- to be passed around as a 'Proxy'.
-length' :: forall n a. (KnownNat n)
-        => Vector n a -> Proxy n
+length' :: forall n a.
+           Vector n a -> Proxy n
 length' = V.length'
 {-# inline length' #-}
 


### PR DESCRIPTION
```haskell
knownLength :: forall v n a r. Vector v n a -> (KnownNat n => r) -> r
```

Rather similar to `withSized`, it exposes a `KnownNat` instance for the length of a vector by reading off the length of that vector. Unlike `withSized`, the input vector is already sized, so the `KnownNat n` it exposes has the *same* `n` as vector's size parameter. E.g., `indices :: Vector n a -> [Finite n]; indices v = knownLength v finites` is a function that produces all the indices of a sized vector, with the correct type to be used in `index`.

This does need `unsafeCoerce`, because it's witnessing the fact that the vectors in this library actually are the size they say they are. Since that isn't true by construction alone, the compiler can't be sure of it.