### PR TITLE
Updated indexed-list-literals to new version

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -61,9 +61,7 @@ module Data.Vector.Generic.Sized
     -- ** Initialization
   , empty
   , singleton
-#if !MIN_VERSION_GLASGOW_HASKELL(8,3,0,0)
   , fromTuple
-#endif
   , replicate
   , replicate'
   , generate
@@ -274,10 +272,8 @@ import Prelude
                scanr, scanr1, mapM, mapM_, sequence, sequence_)
 
 
-#if !MIN_VERSION_GLASGOW_HASKELL(8,3,0,0)
 import Data.IndexedListLiterals hiding (toList)
 import qualified Data.IndexedListLiterals as ILL
-#endif
 
 instance (KnownNat n, VG.Vector v a, Read (v a)) => Read (Vector v n a) where
   readPrec = parens $ prec 10 $ do
@@ -552,7 +548,6 @@ singleton :: forall v a. (VG.Vector v a)
 singleton a = Vector (VG.singleton a)
 {-# inline singleton #-}
 
-#if !MIN_VERSION_GLASGOW_HASKELL(8,3,0,0)
 -- | /O(n)/ Construct a vector in a type safe manner
 --   fromTuple (1,2) :: Vector v 2 Int
 --   fromTuple ("hey", "what's", "going", "on") :: Vector v 4 String
@@ -560,7 +555,6 @@ fromTuple :: forall v a input length.
              (VG.Vector v a, IndexedListLiterals input length a, KnownNat length)
           => input -> Vector v length a
 fromTuple = Vector . VG.fromListN (fromIntegral $ natVal $ Proxy @length) . ILL.toList
-#endif
 
 -- | /O(n)/ Construct a vector with the same element in each position where the
 -- length is inferred from the type.

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -54,9 +54,7 @@ module Data.Vector.Sized
     -- ** Initialization
   , empty
   , singleton
-#if !MIN_VERSION_GLASGOW_HASKELL(8,3,0,0)
   , fromTuple
-#endif
   , replicate
   , replicate'
   , generate
@@ -240,9 +238,7 @@ import qualified Data.Vector.Mutable.Sized as VM
 import GHC.TypeLits
 import Data.Finite
 import Data.Proxy
-#if !MIN_VERSION_GLASGOW_HASKELL(8,3,0,0)
 import Data.IndexedListLiterals hiding (toList)
-#endif
 import Control.Monad.Primitive
 import Prelude hiding ( length, null,
                         replicate, (++), concat,
@@ -472,7 +468,6 @@ singleton :: forall a. a -> Vector 1 a
 singleton = V.singleton
 {-# inline singleton #-}
 
-#if !MIN_VERSION_GLASGOW_HASKELL(8,3,0,0)
 -- | /O(n)/ Construct a vector in a type safe manner
 --   fromTuple (1,2) :: Vector 2 Int
 --   fromTuple ("hey", "what's", "going", "on") :: Vector 4 String
@@ -480,7 +475,6 @@ fromTuple :: forall input length ty.
              (IndexedListLiterals input length ty, KnownNat length)
           => input -> Vector length ty
 fromTuple = V.fromTuple
-#endif
 
 -- | /O(n)/ Construct a vector with the same element in each position where the
 -- length is inferred from the type.

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -54,9 +54,7 @@ module Data.Vector.Storable.Sized
     -- ** Initialization
   , empty
   , singleton
-#if !MIN_VERSION_GLASGOW_HASKELL(8,3,0,0)
   , fromTuple
-#endif
   , replicate
   , replicate'
   , generate
@@ -236,9 +234,7 @@ module Data.Vector.Storable.Sized
 
 import qualified Data.Vector.Generic.Sized as V
 import qualified Data.Vector.Storable as VS
-#if !MIN_VERSION_GLASGOW_HASKELL(8,3,0,0)
 import Data.IndexedListLiterals (IndexedListLiterals)
-#endif
 import qualified Data.Vector.Storable.Mutable.Sized as VSM
 import GHC.TypeLits
 import Data.Finite
@@ -480,7 +476,6 @@ singleton :: forall a. (Storable a)
 singleton = V.singleton
 {-# inline singleton #-}
 
-#if !MIN_VERSION_GLASGOW_HASKELL(8,3,0,0)
 -- | /O(n)/ Construct a vector in a type safe manner
 --   fromTuple (1,2) :: Vector 2 Int
 --   fromTuple ("hey", "what's", "going", "on") :: Vector 4 String
@@ -489,7 +484,6 @@ fromTuple :: forall a input length.
           => input -> Vector length a
 fromTuple = V.fromTuple
 {-# inline fromTuple #-}
-#endif
 
 -- | /O(n)/ Construct a vector with the same element in each position where the
 -- length is inferred from the type.

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,6 @@ packages:
 - '.'
 extra-deps:
 - finite-typelits-0.1.0.0
-- indexed-list-literals-0.1.0.1
+- indexed-list-literals-0.2.0.0
 flags: {}
 extra-package-dbs: []

--- a/vector-sized.cabal
+++ b/vector-sized.cabal
@@ -32,8 +32,7 @@ library
                      , deepseq >= 1.1 && < 1.5
                      , finite-typelits >= 0.1
                      , primitive >= 0.5 && < 0.7
-  if impl(ghc < 8.3)
-    build-depends: indexed-list-literals >= 0.1.0.1
+                     , indexed-list-literals >= 0.2.0.0
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
Removed the CPP excluding fromTuple from GHC 8.4 builds as indexed-list-literals
is now compatible with GHC 8.4