### PR TITLE
not-home haddock annotations for Internal modules, for more helpful linking

### DIFF
--- a/src/Data/Vector/Generic/Mutable/Sized/Internal.hs
+++ b/src/Data/Vector/Generic/Mutable/Sized/Internal.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# OPTIONS_HADDOCK not-home            #-}
 
 module Data.Vector.Generic.Mutable.Sized.Internal
   ( MVector(..)

--- a/src/Data/Vector/Generic/Sized/Internal.hs
+++ b/src/Data/Vector/Generic/Sized/Internal.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
+{-# OPTIONS_HADDOCK not-home            #-}
 
 module Data.Vector.Generic.Sized.Internal
   ( Vector(..)


### PR DESCRIPTION
Added `not-home` haddock annotations to Internal modules, so that links to the definition of those data types to go the normal Generic modules instead of the Internal ones.