### PR TITLE
Get rid of (hopefully all) redundant KnownNat constraints

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -370,26 +370,26 @@ knownLength' (Vector v) x = case someNatVal (fromIntegral (VG.length v)) of
   Nothing -> error "impossible: Vector has negative length"
 
 -- | /O(1)/ Safe indexing using a 'Finite'.
-index :: forall v n a. (KnownNat n, VG.Vector v a)
+index :: forall v n a. VG.Vector v a
       => Vector v n a -> Finite n -> a
-index (Vector v) i = v `VG.unsafeIndex` fromIntegral i
+index (Vector v) (Finite i) = v `VG.unsafeIndex` fromIntegral i
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
-index' :: forall v n m a p. (KnownNat n, KnownNat m, VG.Vector v a)
+index' :: forall v n m a p. (KnownNat n, VG.Vector v a)
        => Vector v (n+m+1) a -> p n -> a
 index' (Vector v) p = v `VG.unsafeIndex` i
   where i = fromIntegral (natVal p)
 {-# inline index' #-}
 
 -- | /O(1)/ Indexing using an Int without bounds checking.
-unsafeIndex :: forall v n a. (KnownNat n, VG.Vector v a)
+unsafeIndex :: forall v n a. VG.Vector v a
       => Vector v n a -> Int -> a
 unsafeIndex (Vector v) i = v `VG.unsafeIndex` i
 {-# inline unsafeIndex #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector.
-head :: forall v n a. (VG.Vector v a)
+head :: forall v n a. VG.Vector v a
      => Vector v (1+n) a -> a
 head (Vector v) = VG.unsafeHead v
 {-# inline head #-}
@@ -401,33 +401,33 @@ last (Vector v) = VG.unsafeLast v
 {-# inline last #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) an arbitrary element by its index.
-ix :: forall v n a f. (KnownNat n, VG.Vector v a, Functor f)
+ix :: forall v n a f. (VG.Vector v a, Functor f)
    => Finite n -> (a -> f a) -> Vector v n a -> f (Vector v n a)
-ix n f vector = (\x -> vector // [(fromInteger $ getFinite n, x)]) <$> f (index vector n)
+ix n f vector = (\x -> vector // [(n, x)]) <$> f (index vector n)
 {-# inline ix #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the first element of a non-empty vector.
-_head :: forall v n a f. (KnownNat n, VG.Vector v a, Functor f)
+_head :: forall v n a f. (VG.Vector v a, Functor f)
       => (a -> f a) -> Vector v (1+n) a -> f (Vector v (1+n) a)
 _head f vector = (\x -> cons x $ tail vector) <$> f (head vector)
 {-# inline _head #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the last element of a non-empty vector.
-_last :: forall v n a f. (KnownNat n, VG.Vector v a, Functor f)
+_last :: forall v n a f. (VG.Vector v a, Functor f)
        => (a -> f a) -> Vector v (n+1) a -> f (Vector v (n+1) a)
 _last f vector = (\x -> snoc (init vector) x) <$> f (last vector)
 {-# inline _last #-}
 
 -- | /O(1)/ Safe indexing in a monad. See the documentation for 'VG.indexM' for
 -- an explanation of why this is useful.
-indexM :: forall v n a m. (KnownNat n, VG.Vector v a, Monad m)
+indexM :: forall v n a m. (VG.Vector v a, Monad m)
       => Vector v n a -> Finite n -> m a
-indexM (Vector v) i = v `VG.indexM` fromIntegral i
+indexM (Vector v) (Finite i) = v `VG.indexM` fromIntegral i
 {-# inline indexM #-}
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
-indexM' :: forall v n k a m p. (KnownNat n, KnownNat k, VG.Vector v a, Monad m)
+indexM' :: forall v n k a m p. (KnownNat n, VG.Vector v a, Monad m)
       => Vector v (n+k) a -> p n -> m a
 indexM' (Vector v) p = v `VG.indexM` i
   where i = fromIntegral (natVal p)
@@ -435,28 +435,28 @@ indexM' (Vector v) p = v `VG.indexM` i
 
 -- | /O(1)/ Indexing using an Int without bounds checking. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
-unsafeIndexM :: forall v n a m. (KnownNat n, VG.Vector v a, Monad m)
+unsafeIndexM :: forall v n a m. (VG.Vector v a, Monad m)
       => Vector v n a -> Int -> m a
 unsafeIndexM (Vector v) i = v `VG.unsafeIndexM` i
 {-# inline unsafeIndexM #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
-headM :: forall v n a m. (KnownNat n, VG.Vector v a, Monad m)
+headM :: forall v n a m. (VG.Vector v a, Monad m)
       => Vector v (1+n) a -> m a
 headM (Vector v) = VG.unsafeHeadM v
 {-# inline headM #-}
 
 -- | /O(1)/ Yield the last element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
-lastM :: forall v n a m. (KnownNat n, VG.Vector v a, Monad m)
+lastM :: forall v n a m. (VG.Vector v a, Monad m)
       => Vector v (n+1) a -> m a
 lastM (Vector v) = VG.unsafeLastM v
 {-# inline lastM #-}
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an inferred
 -- length argument.
-slice :: forall v i n m a p. (KnownNat i, KnownNat n, KnownNat m, VG.Vector v a)
+slice :: forall v i n m a p. (KnownNat i, KnownNat n, VG.Vector v a)
       => p i -- ^ starting index
       -> Vector v (i+n+m) a
       -> Vector v n a
@@ -468,7 +468,7 @@ slice start (Vector v) = Vector (VG.unsafeSlice i n v)
 -- | /O(1)/ Yield a slice of the vector without copying it with an explicit
 -- length argument.
 slice' :: forall v i n m a p
-        . (KnownNat i, KnownNat n, KnownNat m, VG.Vector v a)
+        . (KnownNat i, KnownNat n, VG.Vector v a)
        => p i -- ^ starting index
        -> p n -- ^ length
        -> Vector v (i+n+m) a
@@ -493,7 +493,7 @@ tail (Vector v) = Vector (VG.unsafeTail v)
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is inferred from the
 -- type.
-take :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a)
+take :: forall v n m a. (KnownNat n, VG.Vector v a)
      => Vector v (n+m) a -> Vector v n a
 take (Vector v) = Vector (VG.unsafeTake i v)
   where i = fromIntegral (natVal (Proxy :: Proxy n))
@@ -502,7 +502,7 @@ take (Vector v) = Vector (VG.unsafeTake i v)
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is given explicitly
 -- as a 'Proxy' argument.
-take' :: forall v n m a p. (KnownNat n, KnownNat m, VG.Vector v a)
+take' :: forall v n m a p. (KnownNat n, VG.Vector v a)
       => p n -> Vector v (n+m) a -> Vector v n a
 take' _ = take
 {-# inline take' #-}
@@ -510,7 +510,7 @@ take' _ = take
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- inferred from the type.
-drop :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a)
+drop :: forall v n m a. (KnownNat n, VG.Vector v a)
      => Vector v (n+m) a -> Vector v m a
 drop (Vector v) = Vector (VG.unsafeDrop i v)
   where i = fromIntegral (natVal (Proxy :: Proxy n))
@@ -519,14 +519,14 @@ drop (Vector v) = Vector (VG.unsafeDrop i v)
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- givel explicitly as a 'Proxy' argument.
-drop' :: forall v n m a p. (KnownNat n, KnownNat m, VG.Vector v a)
+drop' :: forall v n m a p. (KnownNat n, VG.Vector v a)
       => p n -> Vector v (n+m) a -> Vector v m a
 drop' _ = drop
 {-# inline drop' #-}
 
 -- | /O(1)/ Yield the first n elements paired with the remainder without copying.
 -- The lengths of the resultant vector are inferred from the type.
-splitAt :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a)
+splitAt :: forall v n m a. (KnownNat n, VG.Vector v a)
         => Vector v (n+m) a -> (Vector v n a, Vector v m a)
 splitAt (Vector v) = (Vector a, Vector b)
   where i = fromIntegral (natVal (Proxy :: Proxy n))
@@ -536,7 +536,7 @@ splitAt (Vector v) = (Vector a, Vector b)
 -- | /O(1)/ Yield the first n elements paired with the remainder without
 -- copying.  The length of the first resultant vector is passed explicitly as a
 -- 'Proxy' argument.
-splitAt' :: forall v n m a p. (KnownNat n, KnownNat m, VG.Vector v a)
+splitAt' :: forall v n m a p. (KnownNat n, VG.Vector v a)
          => p n -> Vector v (n+m) a -> (Vector v n a, Vector v m a)
 splitAt' _ = splitAt
 {-# inline splitAt' #-}
@@ -757,7 +757,7 @@ force (Vector v) = Vector (VG.force v)
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
 --
-(//) :: (VG.Vector v a)
+(//) :: VG.Vector v a
      => Vector v m a    -- ^ initial vector (of length @m@)
      -> [(Finite m, a)] -- ^ list of index/value pairs (of length @n@)
      -> Vector v m a
@@ -1286,7 +1286,7 @@ foldl f z = VG.foldl f z . fromSized
 {-# inline foldl #-}
 
 -- | /O(n)/ Left fold on non-empty vectors
-foldl1 :: (VG.Vector v a, KnownNat n) => (a -> a -> a) -> Vector v (1+n) a -> a
+foldl1 :: VG.Vector v a => (a -> a -> a) -> Vector v (1+n) a -> a
 foldl1 f = VG.foldl1 f . fromSized
 {-# inline foldl1 #-}
 
@@ -1296,7 +1296,7 @@ foldl' f z = VG.foldl' f z . fromSized
 {-# inline foldl' #-}
 
 -- | /O(n)/ Left fold on non-empty vectors with strict accumulator
-foldl1' :: (VG.Vector v a, KnownNat n) => (a -> a -> a) -> Vector v (1+n) a -> a
+foldl1' :: VG.Vector v a => (a -> a -> a) -> Vector v (1+n) a -> a
 foldl1' f = VG.foldl1' f . fromSized
 {-# inline foldl1' #-}
 
@@ -1306,7 +1306,7 @@ foldr f z = VG.foldr f z . fromSized
 {-# inline foldr #-}
 
 -- | /O(n)/ Right fold on non-empty vectors
-foldr1 :: (VG.Vector v a, KnownNat n) => (a -> a -> a) -> Vector v (n+1) a -> a
+foldr1 :: VG.Vector v a => (a -> a -> a) -> Vector v (n+1) a -> a
 foldr1 f = VG.foldr1 f . fromSized
 {-# inline foldr1 #-}
 
@@ -1316,7 +1316,7 @@ foldr' f z = VG.foldr' f z . fromSized
 {-# inline foldr' #-}
 
 -- | /O(n)/ Right fold on non-empty vectors with strict accumulator
-foldr1' :: (VG.Vector v a, KnownNat n) => (a -> a -> a) -> Vector v (n+1) a -> a
+foldr1' :: VG.Vector v a => (a -> a -> a) -> Vector v (n+1) a -> a
 foldr1' f = VG.foldr1' f . fromSized
 {-# inline foldr1' #-}
 
@@ -1375,49 +1375,49 @@ product = VG.product . fromSized
 {-# inline product #-}
 
 -- | /O(n)/ Yield the maximum element of the non-empty vector.
-maximum :: (VG.Vector v a, Ord a, KnownNat n) => Vector v (n+1) a -> a
+maximum :: (VG.Vector v a, Ord a) => Vector v (n+1) a -> a
 maximum = VG.maximum . fromSized
 {-# inline maximum #-}
 
 -- | /O(n)/ Yield the maximum element of the non-empty vector according to the
 -- given comparison function.
-maximumBy :: (VG.Vector v a, KnownNat n)
+maximumBy :: VG.Vector v a
           => (a -> a -> Ordering) -> Vector v (n+1) a -> a
 maximumBy cmpr = VG.maximumBy cmpr . fromSized
 {-# inline maximumBy #-}
 
 -- | /O(n)/ Yield the minimum element of the non-empty vector.
-minimum :: (VG.Vector v a, Ord a, KnownNat n) => Vector v (n+1) a -> a
+minimum :: (VG.Vector v a, Ord a) => Vector v (n+1) a -> a
 minimum = VG.minimum . fromSized
 {-# inline minimum #-}
 
 -- | /O(n)/ Yield the minimum element of the non-empty vector according to the
 -- given comparison function.
-minimumBy :: (VG.Vector v a, KnownNat n)
+minimumBy :: VG.Vector v a
           => (a -> a -> Ordering) -> Vector v (n+1) a -> a
 minimumBy cmpr = VG.minimumBy cmpr . fromSized
 {-# inline minimumBy #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector.
-maxIndex :: (VG.Vector v a, Ord a, KnownNat n) => Vector v (n+1) a -> Finite (n+1)
+maxIndex :: (VG.Vector v a, Ord a) => Vector v (n+1) a -> Finite (n+1)
 maxIndex = Finite . fromIntegral . VG.maxIndex . fromSized
 {-# inline maxIndex #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector
 -- according to the given comparison function.
-maxIndexBy :: (VG.Vector v a, KnownNat n)
+maxIndexBy :: VG.Vector v a
            => (a -> a -> Ordering) -> Vector v (n+1) a -> Finite (n + 1)
 maxIndexBy cmpr = Finite . fromIntegral . VG.maxIndexBy cmpr . fromSized
 {-# inline maxIndexBy #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector.
-minIndex :: (VG.Vector v a, Ord a, KnownNat n) => Vector v (n+1) a -> Finite (n+1)
+minIndex :: (VG.Vector v a, Ord a) => Vector v (n+1) a -> Finite (n+1)
 minIndex = Finite . fromIntegral . VG.minIndex . fromSized
 {-# inline minIndex #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector
 -- according to the given comparison function.
-minIndexBy :: (VG.Vector v a, KnownNat n)
+minIndexBy :: VG.Vector v a
            => (a -> a -> Ordering) -> Vector v (n+1) a -> Finite (n + 1)
 minIndexBy cmpr = Finite . fromIntegral . VG.minIndexBy cmpr . fromSized
 {-# inline minIndexBy #-}
@@ -1435,7 +1435,7 @@ ifoldM m z = VG.ifoldM (\x -> m x . Finite . fromIntegral) z . fromSized
 {-# inline ifoldM #-}
 
 -- | /O(n)/ Monadic fold over non-empty vectors
-fold1M :: (Monad m, VG.Vector v a, KnownNat n)
+fold1M :: (Monad m, VG.Vector v a)
        => (a -> a -> m a) -> Vector v (1+n) a -> m a
 fold1M m = VG.fold1M m . fromSized
 {-# inline fold1M #-}
@@ -1453,7 +1453,7 @@ ifoldM' m z = VG.ifoldM' (\x -> m x . Finite . fromIntegral) z . fromSized
 {-# inline ifoldM' #-}
 
 -- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator
-fold1M' :: (Monad m, VG.Vector v a, KnownNat n)
+fold1M' :: (Monad m, VG.Vector v a)
         => (a -> a -> m a) -> Vector v (n+1) a -> m a
 fold1M' m = VG.fold1M' m . fromSized
 {-# inline fold1M' #-}
@@ -1472,7 +1472,7 @@ ifoldM_ m z = VG.ifoldM_ (\x -> m x . Finite . fromIntegral)  z . fromSized
 {-# inline ifoldM_ #-}
 
 -- | /O(n)/ Monadic fold over non-empty vectors that discards the result
-fold1M_ :: (Monad m, VG.Vector v a, KnownNat n)
+fold1M_ :: (Monad m, VG.Vector v a)
         => (a -> a -> m a) -> Vector v (n+1) a -> m ()
 fold1M_ m = VG.fold1M_ m . fromSized
 {-# inline fold1M_ #-}
@@ -1492,7 +1492,7 @@ ifoldM'_ m z = VG.ifoldM'_ (\x -> m x . Finite . fromIntegral) z . fromSized
 
 -- | /O(n)/ Monad fold over non-empty vectors with strict accumulator
 -- that discards the result
-fold1M'_ :: (Monad m, VG.Vector v a, KnownNat n)
+fold1M'_ :: (Monad m, VG.Vector v a)
          => (a -> a -> m a) -> Vector v (n+1) a -> m ()
 fold1M'_ m = VG.fold1M'_ m . fromSized
 {-# inline fold1M'_ #-}
@@ -1552,12 +1552,12 @@ scanl' f z = withVectorUnsafe (VG.scanl' f z )
 {-# inline scanl' #-}
 
 -- | /O(n)/ Scan over a non-empty vector
-scanl1 :: (VG.Vector v a, KnownNat n) => (a -> a -> a) -> Vector v (n+1) a -> Vector v (n+1) a
+scanl1 :: VG.Vector v a => (a -> a -> a) -> Vector v (n+1) a -> Vector v (n+1) a
 scanl1 f = withVectorUnsafe (VG.scanl1 f )
 {-# inline scanl1 #-}
 
 -- | /O(n)/ Scan over a non-empty vector with a strict accumulator
-scanl1' :: (VG.Vector v a, KnownNat n) => (a -> a -> a) -> Vector v (n+1) a -> Vector v (n+1) a
+scanl1' :: VG.Vector v a => (a -> a -> a) -> Vector v (n+1) a -> Vector v (n+1) a
 scanl1' f = withVectorUnsafe (VG.scanl1' f )
 {-# inline scanl1' #-}
 
@@ -1592,13 +1592,13 @@ scanr' f z = withVectorUnsafe (VG.scanr' f z )
 {-# inline scanr' #-}
 
 -- | /O(n)/ Right-to-left scan over a non-empty vector
-scanr1 :: (VG.Vector v a, KnownNat n) => (a -> a -> a) -> Vector v (n+1) a -> Vector v (n+1) a
+scanr1 :: VG.Vector v a => (a -> a -> a) -> Vector v (n+1) a -> Vector v (n+1) a
 scanr1 f = withVectorUnsafe (VG.scanr1 f )
 {-# inline scanr1 #-}
 
 -- | /O(n)/ Right-to-left scan over a non-empty vector with a strict
 -- accumulator
-scanr1' :: (VG.Vector v a, KnownNat n) => (a -> a -> a) -> Vector v (n+1) a -> Vector v (n+1) a
+scanr1' :: VG.Vector v a => (a -> a -> a) -> Vector v (n+1) a -> Vector v (n+1) a
 scanr1' f = withVectorUnsafe (VG.scanr1' f )
 {-# inline scanr1' #-}
 
@@ -1706,7 +1706,8 @@ toSized v
 -- a 'Data.Vector.Generic.Sized.Vector' with the correct size parameter
 -- @n@.
 withSized :: forall v a r. VG.Vector v a
-          => v a -> (forall n. KnownNat n => Vector v n a -> r) -> r
+          => v a
+          -> (forall n. KnownNat n => Vector v n a -> r) -> r
 withSized v f = case someNatVal (fromIntegral (VG.length v)) of
   Just (SomeNat (Proxy :: Proxy n)) -> f (Vector v :: Vector v n a)
   Nothing -> error "impossible: Vector has negative length"
@@ -1717,8 +1718,7 @@ fromSized (Vector v) = v
 
 -- | Apply a function on unsized vectors to a sized vector. The function must
 -- preserve the size of the vector, this is not checked.
-withVectorUnsafe :: forall a b v w (n :: Nat). (VG.Vector v a, VG.Vector w b)
-                 => (v a -> w b) -> Vector v n a -> Vector w n b
+withVectorUnsafe :: (v a -> w b) -> Vector v n a -> Vector w n b
 withVectorUnsafe f (Vector v) = Vector (f v)
 {-# inline withVectorUnsafe #-}
 

--- a/src/Data/Vector/Mutable/Sized.hs
+++ b/src/Data/Vector/Mutable/Sized.hs
@@ -99,13 +99,13 @@ type MVector = VGM.MVector VM.MVector
 -- ** Length information
 
 -- | /O(1)/ Yield the length of the mutable vector as an 'Int'.
-length :: forall n s a. (KnownNat n)
+length :: forall n s a. KnownNat n
        => MVector n s a -> Int
 length = VGM.length
 {-# inline length #-}
 
 -- | /O(1)/ Yield the length of the mutable vector as a 'Proxy'.
-length' :: forall n s a. (KnownNat n)
+length' :: forall n s a. ()
         => MVector n s a -> Proxy n
 length' = VGM.length'
 {-# inline length' #-}
@@ -120,7 +120,7 @@ null = VGM.null
 
 -- | /O(1)/ Yield a slice of the mutable vector without copying it with an
 -- inferred length argument.
-slice :: forall i n k s a p. (KnownNat i, KnownNat n, KnownNat k)
+slice :: forall i n k s a p. (KnownNat i, KnownNat n)
       => p i -- ^ starting index
       -> MVector (i+n+k) s a
       -> MVector n s a
@@ -130,7 +130,7 @@ slice = VGM.slice
 -- | /O(1)/ Yield a slice of the mutable vector without copying it with an
 -- explicit length argument.
 slice' :: forall i n k s a p
-        . (KnownNat i, KnownNat n, KnownNat k)
+        . (KnownNat i, KnownNat n)
        => p i -- ^ starting index
        -> p n -- ^ length
        -> MVector (i+n+k) s a
@@ -155,7 +155,7 @@ tail = VGM.tail
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is inferred from the
 -- type.
-take :: forall n k s a. (KnownNat n, KnownNat k)
+take :: forall n k s a. KnownNat n
      => MVector (n+k) s a -> MVector n s a
 take = VGM.take
 {-# inline take #-}
@@ -163,7 +163,7 @@ take = VGM.take
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is given explicitly
 -- as a 'Proxy' argument.
-take' :: forall n k s a p. (KnownNat n, KnownNat k)
+take' :: forall n k s a p. KnownNat n
       => p n -> MVector (n+k) s a -> MVector n s a
 take' = VGM.take'
 {-# inline take' #-}
@@ -171,7 +171,7 @@ take' = VGM.take'
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- inferred from the type.
-drop :: forall n k s a. (KnownNat n, KnownNat k)
+drop :: forall n k s a. KnownNat n
      => MVector (n+k) s a -> MVector k s a
 drop = VGM.drop
 {-# inline drop #-}
@@ -179,14 +179,14 @@ drop = VGM.drop
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- givel explicitly as a 'Proxy' argument.
-drop' :: forall n k s a p. (KnownNat n, KnownNat k)
+drop' :: forall n k s a p. KnownNat n
       => p n -> MVector (n+k) s a -> MVector k s a
 drop' = VGM.drop'
 {-# inline drop' #-}
 
 -- | /O(1)/ Yield the first n elements paired with the remainder without copying.
 -- The lengths of the resultant vector are inferred from the type.
-splitAt :: forall n m s a. (KnownNat n, KnownNat m)
+splitAt :: forall n m s a. KnownNat n
         => MVector (n+m) s a -> (MVector n s a, MVector m s a)
 splitAt = VGM.splitAt
 {-# inline splitAt #-}
@@ -194,7 +194,7 @@ splitAt = VGM.splitAt
 -- | /O(1)/ Yield the first n elements paired with the remainder without
 -- copying.  The length of the first resultant vector is passed explicitly as a
 -- 'Proxy' argument.
-splitAt' :: forall n m s a p. (KnownNat n, KnownNat m)
+splitAt' :: forall n m s a p. KnownNat n
          => p n -> MVector (n+m) s a -> (MVector n s a, MVector m s a)
 splitAt' = VGM.splitAt'
 {-# inline splitAt' #-}
@@ -204,7 +204,7 @@ splitAt' = VGM.splitAt'
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- inferred from the type.
-overlaps :: forall n k s a. (KnownNat n, KnownNat k)
+overlaps :: forall n k s a. ()
          => MVector n s a
          -> MVector k s a
          -> Bool
@@ -290,92 +290,92 @@ clear = VGM.clear
 -- * Accessing individual elements
 
 -- | /O(1)/ Yield the element at a given type-safe position using 'Finite'.
-read :: forall n m a. (KnownNat n, PrimMonad m)
+read :: forall n m a. PrimMonad m
       => MVector n (PrimState m) a -> Finite n -> m a
 read = VGM.read
 {-# inline read #-}
 
 -- | /O(1)/ Yield the element at a given type-safe position using 'Proxy'.
-read' :: forall n k a m p. (KnownNat n, KnownNat k, PrimMonad m)
+read' :: forall n k a m p. (KnownNat k, PrimMonad m)
        => MVector (n+k+1) (PrimState m) a -> p k -> m a
 read' = VGM.read'
 {-# inline read' #-}
 
 -- | /O(1)/ Yield the element at a given 'Int' position without bounds
 -- checking.
-unsafeRead :: forall n a m. (KnownNat n, PrimMonad m)
+unsafeRead :: forall n a m. PrimMonad m
            => MVector n (PrimState m) a -> Int -> m a
 unsafeRead = VGM.unsafeRead
 {-# inline unsafeRead #-}
 
 -- | /O(1)/ Replace the element at a given type-safe position using 'Finite'.
-write :: forall n m a. (KnownNat n, PrimMonad m)
+write :: forall n m a. PrimMonad m
       => MVector n (PrimState m) a -> Finite n -> a -> m ()
 write = VGM.write
 {-# inline write #-}
 
 -- | /O(1)/ Replace the element at a given type-safe position using 'Proxy'.
-write' :: forall n k a m p. (KnownNat n, KnownNat k, PrimMonad m)
+write' :: forall n k a m p. (KnownNat k, PrimMonad m)
        => MVector (n+k+1) (PrimState m) a -> p k -> a -> m ()
 write' = VGM.write'
 {-# inline write' #-}
 
 -- | /O(1)/ Replace the element at a given 'Int' position without bounds
 -- checking.
-unsafeWrite :: forall n m a. (KnownNat n, PrimMonad m)
+unsafeWrite :: forall n m a. PrimMonad m
       => MVector n (PrimState m) a -> Int -> a -> m ()
 unsafeWrite = VGM.unsafeWrite
 {-# inline unsafeWrite #-}
 
 -- | /O(1)/ Modify the element at a given type-safe position using 'Finite'.
-modify :: forall n m a. (KnownNat n, PrimMonad m)
+modify :: forall n m a. PrimMonad m
        => MVector n (PrimState m) a -> (a -> a) -> Finite n -> m ()
 modify = VGM.modify
 {-# inline modify #-}
 
 -- | /O(1)/ Modify the element at a given type-safe position using 'Proxy'.
-modify' :: forall n k a m p. (KnownNat n, KnownNat k, PrimMonad m)
+modify' :: forall n k a m p. (KnownNat k, PrimMonad m)
         => MVector (n+k+1) (PrimState m) a -> (a -> a) -> p k -> m ()
 modify' = VGM.modify'
 {-# inline modify' #-}
 
 -- | /O(1)/ Modify the element at a given 'Int' position without bounds
 -- checking.
-unsafeModify :: forall n m a. (KnownNat n, PrimMonad m)
+unsafeModify :: forall n m a. PrimMonad m
        => MVector n (PrimState m) a -> (a -> a) -> Int -> m ()
 unsafeModify = VGM.unsafeModify
 {-# inline unsafeModify #-}
 
 -- | /O(1)/ Swap the elements at a given type-safe position using 'Finite's.
-swap :: forall n m a. (KnownNat n, PrimMonad m)
+swap :: forall n m a. PrimMonad m
      => MVector n (PrimState m) a -> Finite n -> Finite n -> m ()
 swap = VGM.swap
 {-# inline swap #-}
 
 -- | /O(1)/ Swap the elements at a given 'Int' position without bounds
 -- checking.
-unsafeSwap :: forall n m a. (KnownNat n, PrimMonad m)
+unsafeSwap :: forall n m a. PrimMonad m
            => MVector n (PrimState m) a -> Int -> Int -> m ()
 unsafeSwap = VGM.unsafeSwap
 {-# inline unsafeSwap #-}
 
 -- | /O(1)/ Replace the element at a given type-safe position and return
 -- the old element, using 'Finite'.
-exchange :: forall n m a. (KnownNat n, PrimMonad m)
+exchange :: forall n m a. PrimMonad m
          => MVector n (PrimState m) a -> Finite n -> a -> m a
 exchange = VGM.exchange
 {-# inline exchange #-}
 
 -- | /O(1)/ Replace the element at a given type-safe position and return
 -- the old element, using 'Finite'.
-exchange' :: forall n k a m p. (KnownNat n, KnownNat k, PrimMonad m)
+exchange' :: forall n k a m p. (KnownNat k, PrimMonad m)
           => MVector (n+k+1) (PrimState m) a -> p k -> a -> m a
 exchange' = VGM.exchange'
 {-# inline exchange' #-}
 
 -- | /O(1)/ Replace the element at a given 'Int' position and return
 -- the old element. No bounds checks are performed.
-unsafeExchange :: forall n m a. (KnownNat n, PrimMonad m)
+unsafeExchange :: forall n m a. PrimMonad m
          => MVector n (PrimState m) a -> Int -> a -> m a
 unsafeExchange = VGM.unsafeExchange
 {-# inline unsafeExchange #-}
@@ -385,7 +385,7 @@ unsafeExchange = VGM.unsafeExchange
 
 -- | Compute the next (lexicographically) permutation of a given vector
 -- in-place.  Returns 'False' when the input is the last permutation.
-nextPermutation :: forall n e m. (KnownNat n, Ord e, PrimMonad m)
+nextPermutation :: forall n e m. (Ord e, PrimMonad m)
                 => MVector n (PrimState m) e -> m Bool
 nextPermutation = VGM.nextPermutation
 {-# inline nextPermutation #-}

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -292,19 +292,19 @@ knownLength' :: forall n a r.
 knownLength' = V.knownLength'
 
 -- | /O(1)/ Safe indexing using a 'Finite'.
-index :: forall n a. KnownNat n
+index :: forall n a. ()
       => Vector n a -> Finite n -> a
 index = V.index
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
-index' :: forall n m a p. (KnownNat n, KnownNat m)
+index' :: forall n m a p. KnownNat n
        => Vector (n+m+1) a -> p n -> a
 index' = V.index'
 {-# inline index' #-}
 
 -- | /O(1)/ Indexing using an Int without bounds checking.
-unsafeIndex :: forall n a. KnownNat n
+unsafeIndex :: forall n a. ()
       => Vector n a -> Int -> a
 unsafeIndex = V.unsafeIndex
 {-# inline unsafeIndex #-}
@@ -320,61 +320,61 @@ last = V.last
 {-# inline last #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) an arbitrary element by its index.
-ix :: forall n a f. (KnownNat n, Functor f)
+ix :: forall n a f. Functor f
    => Finite n -> (a -> f a) -> Vector n a -> f (Vector n a)
 ix = V.ix
 {-# inline ix #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the first element of a non-empty vector.
-_head :: forall n a f. (KnownNat n, Functor f)
+_head :: forall n a f. Functor f
    => (a -> f a) -> Vector (1+n) a -> f (Vector (1+n) a)
 _head = V._head
 {-# inline _head #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the last element of a non-empty vector.
-_last :: forall n a f. (KnownNat n, Functor f)
+_last :: forall n a f. Functor f
       => (a -> f a) -> Vector (n+1) a -> f (Vector (n+1) a)
 _last = V._last
 {-# inline _last #-}
 
 -- | /O(1)/ Safe indexing in a monad. See the documentation for 'VG.indexM' for
 -- an explanation of why this is useful.
-indexM :: forall n a m. (KnownNat n, Monad m)
+indexM :: forall n a m. Monad m
       => Vector n a -> Finite n -> m a
 indexM = V.indexM
 {-# inline indexM #-}
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
-indexM' :: forall n k a m p. (KnownNat n, KnownNat k, Monad m)
+indexM' :: forall n k a m p. (KnownNat n, Monad m)
       => Vector (n+k) a -> p n -> m a
 indexM' = V.indexM'
 {-# inline indexM' #-}
 
 -- | /O(1)/ Indexing using an Int without bounds checking. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
-unsafeIndexM :: forall n a m. (KnownNat n, Monad m)
+unsafeIndexM :: forall n a m. Monad m
       => Vector n a -> Int -> m a
 unsafeIndexM = V.unsafeIndexM
 {-# inline unsafeIndexM #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
-headM :: forall n a m. (KnownNat n, Monad m)
+headM :: forall n a m. Monad m
       => Vector (1+n) a -> m a
 headM = V.headM
 {-# inline headM #-}
 
 -- | /O(1)/ Yield the last element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
-lastM :: forall n a m. (KnownNat n, Monad m)
+lastM :: forall n a m. Monad m
       => Vector (n+1) a -> m a
 lastM = V.lastM
 {-# inline lastM #-}
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an inferred
 -- length argument.
-slice :: forall i n m a p. (KnownNat i, KnownNat n, KnownNat m)
+slice :: forall i n m a p. (KnownNat i, KnownNat n)
       => p i -- ^ starting index
       -> Vector (i+n+m) a
       -> Vector n a
@@ -383,7 +383,7 @@ slice = V.slice
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an explicit
 -- length argument.
-slice' :: forall i n m a p. (KnownNat i, KnownNat n, KnownNat m)
+slice' :: forall i n m a p. (KnownNat i, KnownNat n)
        => p i -- ^ starting index
        -> p n -- ^ length
        -> Vector (i+n+m) a
@@ -406,7 +406,7 @@ tail = V.tail
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is inferred from the
 -- type.
-take :: forall n m a. (KnownNat n, KnownNat m)
+take :: forall n m a. KnownNat n
      => Vector (n+m) a -> Vector n a
 take = V.take
 {-# inline take #-}
@@ -414,7 +414,7 @@ take = V.take
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is given explicitly
 -- as a 'Proxy' argument.
-take' :: forall n m a p. (KnownNat n, KnownNat m)
+take' :: forall n m a p. KnownNat n
       => p n -> Vector (n+m) a -> Vector n a
 take' = V.take'
 {-# inline take' #-}
@@ -422,7 +422,7 @@ take' = V.take'
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- inferred from the type.
-drop :: forall n m a. (KnownNat n, KnownNat m)
+drop :: forall n m a. KnownNat n
      => Vector (n+m) a -> Vector m a
 drop = V.drop
 {-# inline drop #-}
@@ -430,14 +430,14 @@ drop = V.drop
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- givel explicitly as a 'Proxy' argument.
-drop' :: forall n m a p. (KnownNat n, KnownNat m)
+drop' :: forall n m a p. KnownNat n
       => p n -> Vector (n+m) a -> Vector m a
 drop' = V.drop'
 {-# inline drop' #-}
 
 -- | /O(1)/ Yield the first n elements paired with the remainder without copying.
 -- The lengths of the resultant vector are inferred from the type.
-splitAt :: forall n m a. (KnownNat n, KnownNat m)
+splitAt :: forall n m a. KnownNat n
         => Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt = V.splitAt
 {-# inline splitAt #-}
@@ -445,7 +445,7 @@ splitAt = V.splitAt
 -- | /O(1)/ Yield the first n elements paired with the remainder without
 -- copying.  The length of the first resultant vector is passed explicitly as a
 -- 'Proxy' argument.
-splitAt' :: forall n m a p. (KnownNat n, KnownNat m)
+splitAt' :: forall n m a p. KnownNat n
          => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
@@ -1115,7 +1115,7 @@ foldl = V.foldl
 {-# inline foldl #-}
 
 -- | /O(n)/ Left fold on non-empty vectors
-foldl1 :: KnownNat n => (a -> a -> a) -> Vector (1+n) a -> a
+foldl1 :: (a -> a -> a) -> Vector (1+n) a -> a
 foldl1 = V.foldl1
 {-# inline foldl1 #-}
 
@@ -1125,7 +1125,7 @@ foldl' = V.foldl'
 {-# inline foldl' #-}
 
 -- | /O(n)/ Left fold on non-empty vectors with strict accumulator
-foldl1' :: KnownNat n => (a -> a -> a) -> Vector (1+n) a -> a
+foldl1' :: (a -> a -> a) -> Vector (1+n) a -> a
 foldl1' = V.foldl1'
 {-# inline foldl1' #-}
 
@@ -1135,7 +1135,7 @@ foldr = V.foldr
 {-# inline foldr #-}
 
 -- | /O(n)/ Right fold on non-empty vectors
-foldr1 :: KnownNat n => (a -> a -> a) -> Vector (n+1) a -> a
+foldr1 :: (a -> a -> a) -> Vector (n+1) a -> a
 foldr1 = V.foldr1
 {-# inline foldr1 #-}
 
@@ -1145,7 +1145,7 @@ foldr' = V.foldr'
 {-# inline foldr' #-}
 
 -- | /O(n)/ Right fold on non-empty vectors with strict accumulator
-foldr1' :: KnownNat n => (a -> a -> a) -> Vector (n+1) a -> a
+foldr1' :: (a -> a -> a) -> Vector (n+1) a -> a
 foldr1' = V.foldr1'
 {-# inline foldr1' #-}
 
@@ -1204,50 +1204,46 @@ product = V.product
 {-# inline product #-}
 
 -- | /O(n)/ Yield the maximum element of the non-empty vector.
-maximum :: (Ord a, KnownNat n) => Vector (n+1) a -> a
+maximum :: Ord a => Vector (n+1) a -> a
 maximum = V.maximum
 {-# inline maximum #-}
 
 -- | /O(n)/ Yield the maximum element of the non-empty vector according to the
 -- given comparison function.
-maximumBy :: KnownNat n
-          => (a -> a -> Ordering) -> Vector (n+1) a -> a
+maximumBy :: (a -> a -> Ordering) -> Vector (n+1) a -> a
 maximumBy = V.maximumBy
 {-# inline maximumBy #-}
 
 -- | /O(n)/ Yield the minimum element of the non-empty vector.
-minimum :: (Ord a, KnownNat n) => Vector (n+1) a -> a
+minimum :: Ord a => Vector (n+1) a -> a
 minimum = V.minimum
 {-# inline minimum #-}
 
 -- | /O(n)/ Yield the minimum element of the non-empty vector according to the
 -- given comparison function.
-minimumBy :: KnownNat n
-          => (a -> a -> Ordering) -> Vector (n+1) a -> a
+minimumBy :: (a -> a -> Ordering) -> Vector (n+1) a -> a
 minimumBy = V.minimumBy
 {-# inline minimumBy #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector.
-maxIndex :: (Ord a, KnownNat n) => Vector (n+1) a -> Finite (n + 1)
+maxIndex :: Ord a => Vector (n+1) a -> Finite (n + 1)
 maxIndex = V.maxIndex
 {-# inline maxIndex #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector
 -- according to the given comparison function.
-maxIndexBy :: KnownNat n
-           => (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
+maxIndexBy :: (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
 maxIndexBy = V.maxIndexBy
 {-# inline maxIndexBy #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector.
-minIndex :: (Ord a, KnownNat n) => Vector (n+1) a -> Finite (n + 1)
+minIndex :: Ord a => Vector (n+1) a -> Finite (n + 1)
 minIndex = V.minIndex
 {-# inline minIndex #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector
 -- according to the given comparison function.
-minIndexBy :: KnownNat n
-           => (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
+minIndexBy :: (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
 minIndexBy = V.minIndexBy
 {-# inline minIndexBy #-}
 
@@ -1264,8 +1260,7 @@ ifoldM = V.ifoldM
 {-# inline ifoldM #-}
 
 -- | /O(n)/ Monadic fold over non-empty vectors
-fold1M :: (Monad m, KnownNat n)
-       => (a -> a -> m a) -> Vector (1+n) a -> m a
+fold1M :: Monad m => (a -> a -> m a) -> Vector (1+n) a -> m a
 fold1M = V.fold1M
 {-# inline fold1M #-}
 
@@ -1276,53 +1271,45 @@ foldM' = V.foldM'
 
 -- | /O(n)/ Monadic fold with strict accumulator (action applied to each
 -- element and its index)
-ifoldM' :: Monad m
-        => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m a
+ifoldM' :: Monad m => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m a
 ifoldM' = V.ifoldM'
 {-# inline ifoldM' #-}
 
 -- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator
-fold1M' :: (Monad m, KnownNat n)
-        => (a -> a -> m a) -> Vector (n+1) a -> m a
+fold1M' :: Monad m => (a -> a -> m a) -> Vector (n+1) a -> m a
 fold1M' = V.fold1M'
 {-# inline fold1M' #-}
 
 -- | /O(n)/ Monadic fold that discards the result
-foldM_ :: Monad m
-       => (a -> b -> m a) -> a -> Vector n b -> m ()
+foldM_ :: Monad m => (a -> b -> m a) -> a -> Vector n b -> m ()
 foldM_ = V.foldM_
 {-# inline foldM_ #-}
 
 -- | /O(n)/ Monadic fold that discards the result (action applied to
 -- each element and its index)
-ifoldM_ :: Monad m
-        => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m ()
+ifoldM_ :: Monad m => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m ()
 ifoldM_ = V.ifoldM_
 {-# inline ifoldM_ #-}
 
 -- | /O(n)/ Monadic fold over non-empty vectors that discards the result
-fold1M_ :: (Monad m, KnownNat n)
-        => (a -> a -> m a) -> Vector (n+1) a -> m ()
+fold1M_ :: Monad m => (a -> a -> m a) -> Vector (n+1) a -> m ()
 fold1M_ = V.fold1M_
 {-# inline fold1M_ #-}
 
 -- | /O(n)/ Monadic fold with strict accumulator that discards the result
-foldM'_ :: Monad m
-        => (a -> b -> m a) -> a -> Vector n b -> m ()
+foldM'_ :: Monad m => (a -> b -> m a) -> a -> Vector n b -> m ()
 foldM'_ = V.foldM'_
 {-# inline foldM'_ #-}
 
 -- | /O(n)/ Monadic fold with strict accumulator that discards the result
 -- (action applied to each element and its index)
-ifoldM'_ :: Monad m
-         => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m ()
+ifoldM'_ :: Monad m => (a -> Finite n -> b -> m a) -> a -> Vector n b -> m ()
 ifoldM'_ = V.ifoldM'_
 {-# inline ifoldM'_ #-}
 
 -- | /O(n)/ Monad fold over non-empty vectors with strict accumulator
 -- that discards the result
-fold1M'_ :: (Monad m, KnownNat n)
-         => (a -> a -> m a) -> Vector (n+1) a -> m ()
+fold1M'_ :: Monad m => (a -> a -> m a) -> Vector (n+1) a -> m ()
 fold1M'_ = V.fold1M'_
 {-# inline fold1M'_ #-}
 
@@ -1380,12 +1367,12 @@ scanl' = V.scanl'
 {-# inline scanl' #-}
 
 -- | /O(n)/ Scan over a non-empty vector
-scanl1 :: KnownNat n => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
+scanl1 :: (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
 scanl1 = V.scanl1
 {-# inline scanl1 #-}
 
 -- | /O(n)/ Scan over a non-empty vector with a strict accumulator
-scanl1' :: KnownNat n => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
+scanl1' :: (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
 scanl1' = V.scanl1'
 {-# inline scanl1' #-}
 
@@ -1420,13 +1407,13 @@ scanr' = V.scanr'
 {-# inline scanr' #-}
 
 -- | /O(n)/ Right-to-left scan over a non-empty vector
-scanr1 :: KnownNat n => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
+scanr1 :: (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
 scanr1 = V.scanr1
 {-# inline scanr1 #-}
 
 -- | /O(n)/ Right-to-left scan over a non-empty vector with a strict
 -- accumulator
-scanr1' :: KnownNat n => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
+scanr1' :: (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
 scanr1' = V.scanr1'
 {-# inline scanr1' #-}
 

--- a/src/Data/Vector/Storable/Mutable/Sized.hs
+++ b/src/Data/Vector/Storable/Mutable/Sized.hs
@@ -106,7 +106,7 @@ length = VGM.length
 {-# inline length #-}
 
 -- | /O(1)/ Yield the length of the mutable vector as a 'Proxy'.
-length' :: forall n s a. (KnownNat n)
+length' :: forall n s a. ()
         => MVector n s a -> Proxy n
 length' = VGM.length'
 {-# inline length' #-}
@@ -121,7 +121,7 @@ null = VGM.null
 
 -- | /O(1)/ Yield a slice of the mutable vector without copying it with an
 -- inferred length argument.
-slice :: forall i n k s a p. (KnownNat i, KnownNat n, KnownNat k, Storable a)
+slice :: forall i n k s a p. (KnownNat i, KnownNat n, Storable a)
       => p i -- ^ starting index
       -> MVector (i+n+k) s a
       -> MVector n s a
@@ -131,7 +131,7 @@ slice = VGM.slice
 -- | /O(1)/ Yield a slice of the mutable vector without copying it with an
 -- explicit length argument.
 slice' :: forall i n k s a p
-        . (KnownNat i, KnownNat n, KnownNat k, Storable a)
+        . (KnownNat i, KnownNat n, Storable a)
        => p i -- ^ starting index
        -> p n -- ^ length
        -> MVector (i+n+k) s a
@@ -156,7 +156,7 @@ tail = VGM.tail
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is inferred from the
 -- type.
-take :: forall n k s a. (KnownNat n, KnownNat k, Storable a)
+take :: forall n k s a. (KnownNat n, Storable a)
      => MVector (n+k) s a -> MVector n s a
 take = VGM.take
 {-# inline take #-}
@@ -164,7 +164,7 @@ take = VGM.take
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is given explicitly
 -- as a 'Proxy' argument.
-take' :: forall n k s a p. (KnownNat n, KnownNat k, Storable a)
+take' :: forall n k s a p. (KnownNat n, Storable a)
       => p n -> MVector (n+k) s a -> MVector n s a
 take' = VGM.take'
 {-# inline take' #-}
@@ -172,7 +172,7 @@ take' = VGM.take'
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- inferred from the type.
-drop :: forall n k s a. (KnownNat n, KnownNat k, Storable a)
+drop :: forall n k s a. (KnownNat n, Storable a)
      => MVector (n+k) s a -> MVector k s a
 drop = VGM.drop
 {-# inline drop #-}
@@ -180,14 +180,14 @@ drop = VGM.drop
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- givel explicitly as a 'Proxy' argument.
-drop' :: forall n k s a p. (KnownNat n, KnownNat k, Storable a)
+drop' :: forall n k s a p. (KnownNat n, Storable a)
       => p n -> MVector (n+k) s a -> MVector k s a
 drop' = VGM.drop'
 {-# inline drop' #-}
 
 -- | /O(1)/ Yield the first n elements paired with the remainder without copying.
 -- The lengths of the resultant vector are inferred from the type.
-splitAt :: forall n m s a. (KnownNat n, KnownNat m, Storable a)
+splitAt :: forall n m s a. (KnownNat n, Storable a)
         => MVector (n+m) s a -> (MVector n s a, MVector m s a)
 splitAt = VGM.splitAt
 {-# inline splitAt #-}
@@ -195,7 +195,7 @@ splitAt = VGM.splitAt
 -- | /O(1)/ Yield the first n elements paired with the remainder without
 -- copying.  The length of the first resultant vector is passed explicitly as a
 -- 'Proxy' argument.
-splitAt' :: forall n m s a p. (KnownNat n, KnownNat m, Storable a)
+splitAt' :: forall n m s a p. (KnownNat n, Storable a)
          => p n -> MVector (n+m) s a -> (MVector n s a, MVector m s a)
 splitAt' = VGM.splitAt'
 {-# inline splitAt' #-}
@@ -205,7 +205,7 @@ splitAt' = VGM.splitAt'
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- inferred from the type.
-overlaps :: forall n k s a. (KnownNat n, KnownNat k, Storable a)
+overlaps :: forall n k s a. Storable a
          => MVector n s a
          -> MVector k s a
          -> Bool
@@ -291,92 +291,92 @@ clear = VGM.clear
 -- * Accessing individual elements
 
 -- | /O(1)/ Yield the element at a given type-safe position using 'Finite'.
-read :: forall n m a. (KnownNat n, PrimMonad m, Storable a)
+read :: forall n m a. (PrimMonad m, Storable a)
       => MVector n (PrimState m) a -> Finite n -> m a
 read = VGM.read
 {-# inline read #-}
 
 -- | /O(1)/ Yield the element at a given type-safe position using 'Proxy'.
-read' :: forall n k a m p. (KnownNat n, KnownNat k, PrimMonad m, Storable a)
+read' :: forall n k a m p. (KnownNat k, PrimMonad m, Storable a)
        => MVector (n+k+1) (PrimState m) a -> p k -> m a
 read' = VGM.read'
 {-# inline read' #-}
 
 -- | /O(1)/ Yield the element at a given 'Int' position without bounds
 -- checking.
-unsafeRead :: forall n a m. (KnownNat n, PrimMonad m, Storable a)
+unsafeRead :: forall n a m. (PrimMonad m, Storable a)
            => MVector n (PrimState m) a -> Int -> m a
 unsafeRead = VGM.unsafeRead
 {-# inline unsafeRead #-}
 
 -- | /O(1)/ Replace the element at a given type-safe position using 'Finite'.
-write :: forall n m a. (KnownNat n, PrimMonad m, Storable a)
+write :: forall n m a. (PrimMonad m, Storable a)
       => MVector n (PrimState m) a -> Finite n -> a -> m ()
 write = VGM.write
 {-# inline write #-}
 
 -- | /O(1)/ Replace the element at a given type-safe position using 'Proxy'.
-write' :: forall n k a m p. (KnownNat n, KnownNat k, PrimMonad m, Storable a)
+write' :: forall n k a m p. (KnownNat k, PrimMonad m, Storable a)
        => MVector (n+k+1) (PrimState m) a -> p k -> a -> m ()
 write' = VGM.write'
 {-# inline write' #-}
 
 -- | /O(1)/ Replace the element at a given 'Int' position without bounds
 -- checking.
-unsafeWrite :: forall n m a. (KnownNat n, PrimMonad m, Storable a)
+unsafeWrite :: forall n m a. (PrimMonad m, Storable a)
       => MVector n (PrimState m) a -> Int -> a -> m ()
 unsafeWrite = VGM.unsafeWrite
 {-# inline unsafeWrite #-}
 
 -- | /O(1)/ Modify the element at a given type-safe position using 'Finite'.
-modify :: forall n m a. (KnownNat n, PrimMonad m, Storable a)
+modify :: forall n m a. (PrimMonad m, Storable a)
        => MVector n (PrimState m) a -> (a -> a) -> Finite n -> m ()
 modify = VGM.modify
 {-# inline modify #-}
 
 -- | /O(1)/ Modify the element at a given type-safe position using 'Proxy'.
-modify' :: forall n k a m p. (KnownNat n, KnownNat k, PrimMonad m, Storable a)
+modify' :: forall n k a m p. (KnownNat k, PrimMonad m, Storable a)
         => MVector (n+k+1) (PrimState m) a -> (a -> a) -> p k -> m ()
 modify' = VGM.modify'
 {-# inline modify' #-}
 
 -- | /O(1)/ Modify the element at a given 'Int' position without bounds
 -- checking.
-unsafeModify :: forall n m a. (KnownNat n, PrimMonad m, Storable a)
+unsafeModify :: forall n m a. (PrimMonad m, Storable a)
        => MVector n (PrimState m) a -> (a -> a) -> Int -> m ()
 unsafeModify = VGM.unsafeModify
 {-# inline unsafeModify #-}
 
 -- | /O(1)/ Swap the elements at a given type-safe position using 'Finite's.
-swap :: forall n m a. (KnownNat n, PrimMonad m, Storable a)
+swap :: forall n m a. (PrimMonad m, Storable a)
      => MVector n (PrimState m) a -> Finite n -> Finite n -> m ()
 swap = VGM.swap
 {-# inline swap #-}
 
 -- | /O(1)/ Swap the elements at a given 'Int' position without bounds
 -- checking.
-unsafeSwap :: forall n m a. (KnownNat n, PrimMonad m, Storable a)
+unsafeSwap :: forall n m a. (PrimMonad m, Storable a)
            => MVector n (PrimState m) a -> Int -> Int -> m ()
 unsafeSwap = VGM.unsafeSwap
 {-# inline unsafeSwap #-}
 
 -- | /O(1)/ Replace the element at a given type-safe position and return
 -- the old element, using 'Finite'.
-exchange :: forall n m a. (KnownNat n, PrimMonad m, Storable a)
+exchange :: forall n m a. (PrimMonad m, Storable a)
          => MVector n (PrimState m) a -> Finite n -> a -> m a
 exchange = VGM.exchange
 {-# inline exchange #-}
 
 -- | /O(1)/ Replace the element at a given type-safe position and return
 -- the old element, using 'Finite'.
-exchange' :: forall n k a m p. (KnownNat n, KnownNat k, PrimMonad m, Storable a)
+exchange' :: forall n k a m p. (KnownNat k, PrimMonad m, Storable a)
           => MVector (n+k+1) (PrimState m) a -> p k -> a -> m a
 exchange' = VGM.exchange'
 {-# inline exchange' #-}
 
 -- | /O(1)/ Replace the element at a given 'Int' position and return
 -- the old element. No bounds checks are performed.
-unsafeExchange :: forall n m a. (KnownNat n, PrimMonad m, Storable a)
+unsafeExchange :: forall n m a. (PrimMonad m, Storable a)
          => MVector n (PrimState m) a -> Int -> a -> m a
 unsafeExchange = VGM.unsafeExchange
 {-# inline unsafeExchange #-}
@@ -386,7 +386,7 @@ unsafeExchange = VGM.unsafeExchange
 
 -- | Compute the next (lexicographically) permutation of a given vector
 -- in-place.  Returns 'False' when the input is the last permutation.
-nextPermutation :: forall n e m. (KnownNat n, Ord e, PrimMonad m, Storable e)
+nextPermutation :: forall n e m. (Ord e, PrimMonad m, Storable e)
                 => MVector n (PrimState m) e -> m Bool
 nextPermutation = VGM.nextPermutation
 {-# inline nextPermutation #-}

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -293,19 +293,19 @@ knownLength' :: forall n a r. Storable a
 knownLength' = V.knownLength'
 
 -- | /O(1)/ Safe indexing using a 'Finite'.
-index :: forall n a. (KnownNat n, Storable a)
+index :: forall n a. Storable a
       => Vector n a -> Finite n -> a
 index = V.index
 {-# inline index #-}
 
 -- | /O(1)/ Safe indexing using a 'Proxy'.
-index' :: forall n m a p. (KnownNat n, KnownNat m, Storable a)
+index' :: forall n m a p. (KnownNat n, Storable a)
        => Vector (n+m+1) a -> p n -> a
 index' = V.index'
 {-# inline index' #-}
 
 -- | /O(1)/ Indexing using an Int without bounds checking.
-unsafeIndex :: forall n a. (KnownNat n, Storable a)
+unsafeIndex :: forall n a. Storable a
       => Vector n a -> Int -> a
 unsafeIndex = V.unsafeIndex
 {-# inline unsafeIndex #-}
@@ -323,19 +323,19 @@ last = V.last
 {-# inline last #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) an arbitrary element by its index.
-ix :: forall n a f. (KnownNat n, Storable a, Functor f)
+ix :: forall n a f. (Storable a, Functor f)
    => Finite n -> (a -> f a) -> Vector n a -> f (Vector n a)
 ix = V.ix
 {-# inline ix #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the first element of a non-empty vector.
-_head :: forall n a f. (KnownNat n, Storable a, Functor f)
+_head :: forall n a f. (Storable a, Functor f)
       => (a -> f a) -> Vector (1+n) a -> f (Vector (1+n) a)
 _head = V._head
 {-# inline _head #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the last element of a non-empty vector.
-_last :: forall n a f. (KnownNat n, Storable a, Functor f)
+_last :: forall n a f. (Storable a, Functor f)
        => (a -> f a) -> Vector (n+1) a -> f (Vector (n+1) a)
 _last = V._last
 {-# inline _last #-}
@@ -343,42 +343,42 @@ _last = V._last
 
 -- | /O(1)/ Safe indexing in a monad. See the documentation for 'VG.indexM' for
 -- an explanation of why this is useful.
-indexM :: forall n a m. (KnownNat n, Storable a, Monad m)
+indexM :: forall n a m. (Storable a, Monad m)
       => Vector n a -> Finite n -> m a
 indexM = V.indexM
 {-# inline indexM #-}
 
 -- | /O(1)/ Safe indexing in a monad using a 'Proxy'. See the documentation for
 -- 'VG.indexM' for an explanation of why this is useful.
-indexM' :: forall n k a m p. (KnownNat n, KnownNat k, Storable a, Monad m)
+indexM' :: forall n k a m p. (KnownNat n, Storable a, Monad m)
       => Vector (n+k) a -> p n -> m a
 indexM' = V.indexM'
 {-# inline indexM' #-}
 
 -- | /O(1)/ Indexing using an Int without bounds checking. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
-unsafeIndexM :: forall n a m. (KnownNat n, Storable a, Monad m)
+unsafeIndexM :: forall n a m. (Storable a, Monad m)
       => Vector n a -> Int -> m a
 unsafeIndexM = V.unsafeIndexM
 {-# inline unsafeIndexM #-}
 
 -- | /O(1)/ Yield the first element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
-headM :: forall n a m. (KnownNat n, Storable a, Monad m)
+headM :: forall n a m. (Storable a, Monad m)
       => Vector (1+n) a -> m a
 headM = V.headM
 {-# inline headM #-}
 
 -- | /O(1)/ Yield the last element of a non-empty vector in a monad. See the
 -- documentation for 'VG.indexM' for an explanation of why this is useful.
-lastM :: forall n a m. (KnownNat n, Storable a, Monad m)
+lastM :: forall n a m. (Storable a, Monad m)
       => Vector (n+1) a -> m a
 lastM = V.lastM
 {-# inline lastM #-}
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an inferred
 -- length argument.
-slice :: forall i n m a p. (KnownNat i, KnownNat n, KnownNat m, Storable a)
+slice :: forall i n m a p. (KnownNat i, KnownNat n, Storable a)
       => p i -- ^ starting index
       -> Vector (i+n+m) a
       -> Vector n a
@@ -387,7 +387,7 @@ slice = V.slice
 
 -- | /O(1)/ Yield a slice of the vector without copying it with an explicit
 -- length argument.
-slice' :: forall i n m a p. (KnownNat i, KnownNat n, KnownNat m, Storable a)
+slice' :: forall i n m a p. (KnownNat i, KnownNat n, Storable a)
        => p i -- ^ starting index
        -> p n -- ^ length
        -> Vector (i+n+m) a
@@ -412,7 +412,7 @@ tail = V.tail
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is inferred from the
 -- type.
-take :: forall n m a. (KnownNat n, KnownNat m, Storable a)
+take :: forall n m a. (KnownNat n, Storable a)
      => Vector (n+m) a -> Vector n a
 take = V.take
 {-# inline take #-}
@@ -420,7 +420,7 @@ take = V.take
 -- | /O(1)/ Yield the first n elements. The resultant vector always contains
 -- this many elements. The length of the resultant vector is given explicitly
 -- as a 'Proxy' argument.
-take' :: forall n m a p. (KnownNat n, KnownNat m, Storable a)
+take' :: forall n m a p. (KnownNat n, Storable a)
       => p n -> Vector (n+m) a -> Vector n a
 take' = V.take'
 {-# inline take' #-}
@@ -428,7 +428,7 @@ take' = V.take'
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- inferred from the type.
-drop :: forall n m a. (KnownNat n, KnownNat m, Storable a)
+drop :: forall n m a. (KnownNat n, Storable a)
      => Vector (n+m) a -> Vector m a
 drop = V.drop
 {-# inline drop #-}
@@ -436,14 +436,14 @@ drop = V.drop
 -- | /O(1)/ Yield all but the the first n elements. The given vector must
 -- contain at least this many elements The length of the resultant vector is
 -- givel explicitly as a 'Proxy' argument.
-drop' :: forall n m a p. (KnownNat n, KnownNat m, Storable a)
+drop' :: forall n m a p. (KnownNat n, Storable a)
       => p n -> Vector (n+m) a -> Vector m a
 drop' = V.drop'
 {-# inline drop' #-}
 
 -- | /O(1)/ Yield the first n elements paired with the remainder without copying.
 -- The lengths of the resultant vector are inferred from the type.
-splitAt :: forall n m a. (KnownNat n, KnownNat m, Storable a)
+splitAt :: forall n m a. (KnownNat n, Storable a)
         => Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt = V.splitAt
 {-# inline splitAt #-}
@@ -451,7 +451,7 @@ splitAt = V.splitAt
 -- | /O(1)/ Yield the first n elements paired with the remainder without
 -- copying.  The length of the first resultant vector is passed explicitly as a
 -- 'Proxy' argument.
-splitAt' :: forall n m a p. (KnownNat n, KnownNat m, Storable a)
+splitAt' :: forall n m a p. (KnownNat n, Storable a)
          => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
@@ -1171,7 +1171,7 @@ foldl = V.foldl
 {-# inline foldl #-}
 
 -- | /O(n)/ Left fold on non-empty vectors
-foldl1 :: (Storable a, KnownNat n) => (a -> a -> a) -> Vector (1+n) a -> a
+foldl1 :: Storable a => (a -> a -> a) -> Vector (1+n) a -> a
 foldl1 = V.foldl1
 {-# inline foldl1 #-}
 
@@ -1181,7 +1181,7 @@ foldl' = V.foldl'
 {-# inline foldl' #-}
 
 -- | /O(n)/ Left fold on non-empty vectors with strict accumulator
-foldl1' :: (Storable a, KnownNat n) => (a -> a -> a) -> Vector (1+n) a -> a
+foldl1' :: Storable a => (a -> a -> a) -> Vector (1+n) a -> a
 foldl1' = V.foldl1'
 {-# inline foldl1' #-}
 
@@ -1191,7 +1191,7 @@ foldr = V.foldr
 {-# inline foldr #-}
 
 -- | /O(n)/ Right fold on non-empty vectors
-foldr1 :: (Storable a, KnownNat n) => (a -> a -> a) -> Vector (n+1) a -> a
+foldr1 :: Storable a => (a -> a -> a) -> Vector (n+1) a -> a
 foldr1 = V.foldr1
 {-# inline foldr1 #-}
 
@@ -1201,7 +1201,7 @@ foldr' = V.foldr'
 {-# inline foldr' #-}
 
 -- | /O(n)/ Right fold on non-empty vectors with strict accumulator
-foldr1' :: (Storable a, KnownNat n) => (a -> a -> a) -> Vector (n+1) a -> a
+foldr1' :: Storable a => (a -> a -> a) -> Vector (n+1) a -> a
 foldr1' = V.foldr1'
 {-# inline foldr1' #-}
 
@@ -1260,49 +1260,49 @@ product = V.product
 {-# inline product #-}
 
 -- | /O(n)/ Yield the maximum element of the non-empty vector.
-maximum :: (Storable a, Ord a, KnownNat n) => Vector (n+1) a -> a
+maximum :: (Storable a, Ord a) => Vector (n+1) a -> a
 maximum = V.maximum
 {-# inline maximum #-}
 
 -- | /O(n)/ Yield the maximum element of the non-empty vector according to the
 -- given comparison function.
-maximumBy :: (Storable a, KnownNat n)
+maximumBy :: Storable a
           => (a -> a -> Ordering) -> Vector (n+1) a -> a
 maximumBy = V.maximumBy
 {-# inline maximumBy #-}
 
 -- | /O(n)/ Yield the minimum element of the non-empty vector.
-minimum :: (Storable a, Ord a, KnownNat n) => Vector (n+1) a -> a
+minimum :: (Storable a, Ord a) => Vector (n+1) a -> a
 minimum = V.minimum
 {-# inline minimum #-}
 
 -- | /O(n)/ Yield the minimum element of the non-empty vector according to the
 -- given comparison function.
-minimumBy :: (Storable a, KnownNat n)
+minimumBy :: Storable a
           => (a -> a -> Ordering) -> Vector (n+1) a -> a
 minimumBy = V.minimumBy
 {-# inline minimumBy #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector.
-maxIndex :: (Storable a, Ord a, KnownNat n) => Vector (n+1) a -> Finite (n + 1)
+maxIndex :: (Storable a, Ord a) => Vector (n+1) a -> Finite (n + 1)
 maxIndex = V.maxIndex
 {-# inline maxIndex #-}
 
 -- | /O(n)/ Yield the index of the maximum element of the non-empty vector
 -- according to the given comparison function.
-maxIndexBy :: (Storable a, KnownNat n)
+maxIndexBy :: Storable a
            => (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
 maxIndexBy = V.maxIndexBy
 {-# inline maxIndexBy #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector.
-minIndex :: (Storable a, Ord a, KnownNat n) => Vector (n+1) a -> Finite (n + 1)
+minIndex :: (Storable a, Ord a) => Vector (n+1) a -> Finite (n + 1)
 minIndex = V.minIndex
 {-# inline minIndex #-}
 
 -- | /O(n)/ Yield the index of the minimum element of the non-empty vector
 -- according to the given comparison function.
-minIndexBy :: (Storable a, KnownNat n)
+minIndexBy :: Storable a
            => (a -> a -> Ordering) -> Vector (n+1) a -> Finite (n + 1)
 minIndexBy = V.minIndexBy
 {-# inline minIndexBy #-}
@@ -1320,7 +1320,7 @@ ifoldM = V.ifoldM
 {-# inline ifoldM #-}
 
 -- | /O(n)/ Monadic fold over non-empty vectors
-fold1M :: (Monad m, Storable a, KnownNat n)
+fold1M :: (Monad m, Storable a)
        => (a -> a -> m a) -> Vector (1+n) a -> m a
 fold1M = V.fold1M
 {-# inline fold1M #-}
@@ -1338,7 +1338,7 @@ ifoldM' = V.ifoldM'
 {-# inline ifoldM' #-}
 
 -- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator
-fold1M' :: (Monad m, Storable a, KnownNat n)
+fold1M' :: (Monad m, Storable a)
         => (a -> a -> m a) -> Vector (n+1) a -> m a
 fold1M' = V.fold1M'
 {-# inline fold1M' #-}
@@ -1357,7 +1357,7 @@ ifoldM_ = V.ifoldM_
 {-# inline ifoldM_ #-}
 
 -- | /O(n)/ Monadic fold over non-empty vectors that discards the result
-fold1M_ :: (Monad m, Storable a, KnownNat n)
+fold1M_ :: (Monad m, Storable a)
         => (a -> a -> m a) -> Vector (n+1) a -> m ()
 fold1M_ = V.fold1M_
 {-# inline fold1M_ #-}
@@ -1377,7 +1377,7 @@ ifoldM'_ = V.ifoldM'_
 
 -- | /O(n)/ Monad fold over non-empty vectors with strict accumulator
 -- that discards the result
-fold1M'_ :: (Monad m, Storable a, KnownNat n)
+fold1M'_ :: (Monad m, Storable a)
          => (a -> a -> m a) -> Vector (n+1) a -> m ()
 fold1M'_ = V.fold1M'_
 {-# inline fold1M'_ #-}
@@ -1437,12 +1437,12 @@ scanl' = V.scanl'
 {-# inline scanl' #-}
 
 -- | /O(n)/ Scan over a non-empty vector
-scanl1 :: (Storable a, KnownNat n) => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
+scanl1 :: Storable a => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
 scanl1 = V.scanl1
 {-# inline scanl1 #-}
 
 -- | /O(n)/ Scan over a non-empty vector with a strict accumulator
-scanl1' :: (Storable a, KnownNat n) => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
+scanl1' :: Storable a => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
 scanl1' = V.scanl1'
 {-# inline scanl1' #-}
 
@@ -1477,13 +1477,13 @@ scanr' = V.scanr'
 {-# inline scanr' #-}
 
 -- | /O(n)/ Right-to-left scan over a non-empty vector
-scanr1 :: (Storable a, KnownNat n) => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
+scanr1 :: Storable a => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
 scanr1 = V.scanr1
 {-# inline scanr1 #-}
 
 -- | /O(n)/ Right-to-left scan over a non-empty vector with a strict
 -- accumulator
-scanr1' :: (Storable a, KnownNat n) => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
+scanr1' :: Storable a => (a -> a -> a) -> Vector (n+1) a -> Vector (n+1) a
 scanr1' = V.scanr1'
 {-# inline scanr1' #-}
 
@@ -1592,7 +1592,7 @@ fromSized = V.fromSized
 
 -- | Apply a function on unsized vectors to a sized vector. The function must
 -- preserve the size of the vector, this is not checked.
-withVectorUnsafe :: forall a b (n :: Nat). (Storable a, Storable b)
+withVectorUnsafe :: forall a b (n :: Nat). ()
                  => (VS.Vector a -> VS.Vector b) -> Vector n a -> Vector n b
 withVectorUnsafe = V.withVectorUnsafe
 {-# inline withVectorUnsafe #-}


### PR DESCRIPTION
Addresses #43 

Note that `length` technically can be implemented without KnownNat, but I'm leaving it in terms of an implementation that uses `KnownNat` because its invocation could be theoretically inlined/compile-time constant-folded without needing any runtime information.