### PR TITLE
Conditionally enable NoStarIsType to fix build on GHC 8.6

### DIFF
--- a/vector-sized.cabal
+++ b/vector-sized.cabal
@@ -34,6 +34,9 @@ library
                      , distributive >= 0.5 && < 0.7
   default-language:    Haskell2010
 
+  if impl(ghc >= 8.6)
+    default-extensions: NoStarIsType
+
 source-repository head
   type:     git
   location: https://github.com/expipiplus1/vector-sized


### PR DESCRIPTION
This enables the new `NoStarIsType` extension, which is necessary to build `vector-sized` on GHC 8.6 and later, because the type of `concatMap` uses `*` as a binary operator. See the [GHC migration guide](https://ghc.haskell.org/trac/ghc/wiki/Migration/8.6#StarIsType) for more details. (One could use a module qualifier on `*` instead of the conditional default extension, but this approach seems cleaner.)