### PR TITLE
Comonad instance for non-empty boxed sized vectors

### DIFF
--- a/vector-sized.cabal
+++ b/vector-sized.cabal
@@ -32,6 +32,7 @@ library
                      , indexed-list-literals >= 0.2.0.0
                      , adjunctions >= 4.3 && < 4.5
                      , distributive >= 0.5 && < 0.7
+                     , comonad (>=4 && <6)
   default-language:    Haskell2010
 
   if impl(ghc >= 8.6)


### PR DESCRIPTION
Non-empty boxed sized vectors may be given a lawful comonad instance by having:
`extract` be `head`
`duplicate` generate all unique sequences of the argument vector with the same length as it, using wrap-around.

E.g.
```haskell
duplicate [1,2,3,4,5] = [[1,2,3,4,5], [2,3,4,5,1], [3,4,5,1,2], [4,5,1,2,3], [5,1,2,3,4]]
```

This has the potential to be useful, but I don't have a concrete use-case.
Since `adjunctions` already depends on `comonad`, this won't actually incur any additional dependencies.