### PR TITLE
move -XNoStarIsType to CPP

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -14,6 +14,10 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE CPP #-}
 
+#if MIN_VERSION_base(4,12,0)
+{-# LANGUAGE NoStarIsType #-}
+#endif
+
 {-|
 This module reexports the functionality in 'Data.Vector.Generic' which maps well
 to explicity sized vectors.

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -6,6 +6,9 @@
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE CPP                        #-}
 
+#if MIN_VERSION_base(4,12,0)
+{-# LANGUAGE NoStarIsType #-}
+#endif
 
 {-|
 This module re-exports the functionality in 'Data.Vector.Generic.Sized'

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -7,6 +7,10 @@
 {-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE CPP                 #-}
 
+#if MIN_VERSION_base(4,12,0)
+{-# LANGUAGE NoStarIsType #-}
+#endif
+
 {-|
 This module re-exports the functionality in 'Data.Vector.Generic.Sized'
  specialized to 'Data.Vector.Storable'

--- a/vector-sized.cabal
+++ b/vector-sized.cabal
@@ -35,8 +35,8 @@ library
                      , comonad >=4 && <6
   default-language:    Haskell2010
 
-  if impl(ghc >= 8.6)
-    default-extensions: NoStarIsType
+  -- if impl(ghc >= 8.6)
+  --   default-extensions: NoStarIsType
 
 source-repository head
   type:     git


### PR DESCRIPTION
Should fix issues uploading to hackage. (#52)

I recently found out that Hackage is also using ghc 8.4 to build its documentation, and it seems like the whole of hackage is on 8.4, not just the uploading checker.  Someone suggested to me that this might be because of the critical bug in ghc 8.6.1; presumably this state will remain until the release of ghc 8.6.2, which has no definite release schedule as of now.  It might be best to just upload it to hackage in this state at the moment :)