### PR TITLE
Fix .gitignore, add cabal.project, fix CPP issue with Data.Vector.Unboxed.Sized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-
+.ghc.environment.*
+cabal.project.local
 dist
 dist-*
 cabal-dev

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+packages:             ./*.cabal
+optimization:         2
+split-sections:       True

--- a/src/Data/Vector/Unboxed/Sized.hs
+++ b/src/Data/Vector/Unboxed/Sized.hs
@@ -7,6 +7,10 @@
 {-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE CPP                 #-}
 
+#if MIN_VERSION_base(4,12,0)
+{-# LANGUAGE NoStarIsType #-}
+#endif
+
 {-|
 This module re-exports the functionality in 'Data.Vector.Generic.Sized'
  specialized to 'Data.Vector.Unboxed'
@@ -871,7 +875,7 @@ imap = V.imap
 -- | /O(n*m)/ Map a function over a vector and concatenate the results. The
 -- function is required to always return the same length vector.
 concatMap :: (Unbox a, Unbox b)
-          => (a -> Vector m b) -> Vector n a -> Vector (n*m) b
+          => (a -> Vector m b) -> Vector n a -> Vector (n * m) b
 concatMap = V.concatMap
 {-# inline concatMap #-}
 


### PR DESCRIPTION
The main fix is a CPP-related issue vis a vis ``NoStarIsType``, as per #48 - this wasn't done on my contribution, and as a result, this won't build on 8.6 as-is. Additionally, I've added basic support for ``cabal new-build`` - mostly for my own future benefit.