### PR TITLE
SomeSized pattern synonym, for usage as patterns/do blocks/ghci

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -12,6 +13,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE CPP #-}
 
 #if MIN_VERSION_base(4,12,0)
@@ -30,7 +33,7 @@ not exported.
 -}
 
 module Data.Vector.Generic.Sized
-  ( Vector
+  ( Vector(SomeVector)
   , MVector
    -- * Accessors
    -- ** Length information
@@ -248,6 +251,8 @@ module Data.Vector.Generic.Sized
 import Data.Vector.Generic.Sized.Internal
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector as Boxed
+import qualified Data.Vector.Unboxed as Unboxed
+import qualified Data.Vector.Storable as Storable
 import qualified Data.Vector.Generic.Mutable.Sized as SVGM
 import Data.Vector.Generic.Mutable.Sized.Internal
 import GHC.Generics (Generic)
@@ -1759,6 +1764,94 @@ fromSized (Vector v) = v
 withVectorUnsafe :: (v a -> w b) -> Vector v n a -> Vector w n b
 withVectorUnsafe f (Vector v) = Vector (f v)
 {-# inline withVectorUnsafe #-}
+
+-- | Internal existential wrapper used for implementing 'SomeVector'
+-- pattern synonym
+data SV_ v a = forall n. KnownNat n => SV_ (Vector v n a)
+
+-- | Pattern synonym that lets you treat an unsized vector as if it
+-- "contained" a sized vector.  If you pattern match on an unsized vector,
+-- its contents will be the /sized/ vector counterpart.
+--
+-- @
+-- testFunc :: Unsized.Vector Int -> Int
+-- testFunc ('SomeVector' v) =
+--     'sum' ('zipWith' (+) v ('replicate' 1))
+--         -- ^ here, v is `Sized.Vector n Int`, and we have
+--                     `'KnownNat' n`
+-- @
+--
+-- The @n@ type variable will be properly instantiated to whatever the
+-- length of the vector is, and you will also have a @'KnownNat' n@
+-- instance available.  You can get @n@ in scope by turning on
+-- ScopedTypeVariables and matching on @'SomeVector' (v :: Sized.Vector
+-- n Int)@.
+--
+-- Without this, you would otherwise have to use 'withSized' to do the same
+-- thing:
+--
+-- @
+-- testFunc :: Unsized.Vector Int -> Int
+-- testFunc u = 'withSized' u $ \\v ->
+--     'sum' ('zipWith' (+) v ('replicate' 1))
+-- @
+--
+-- Remember that the type of final result of your function (the @Int@,
+-- here) must /not/ depend on @n@.  However, the types of the intermediate
+-- values are allowed to depend on @n@.
+--
+-- This is /especially/ useful in do blocks, where you can pattern match on
+-- the unsized results of actions, to use the sized vector in the rest of
+-- the do block.  You also get a @'KnownNat' n@ constraint for the
+-- remainder of the do block.
+--
+-- @
+-- -- If you had:
+-- getAVector :: IO (Unsized.Vector Int)
+--
+-- main :: IO ()
+-- main = do
+--     SomeVector v <- getAVector -- v is `Sized.Vector n Int`
+--     print v
+--
+--     -- alternatively, get n in scope
+--     SomeVector (v2 :: Sized.Vector n Int) <- getAVector
+--     print v2
+-- @
+--
+-- Remember that the final type of the result of the do block ('()', here)
+-- must not depend on @n@.  However, the 
+--
+-- Also useful in ghci, where you can pattern match to get sized vectors
+-- from unsized vectors.
+--
+-- @
+-- ghci> SomeVector v <- pure (myUnsizedVector :: Unsized.Vector Int)
+--              -- ^ v is `Sized.Vector n Int`
+-- @
+--
+-- This enables interactive exploration with sized vectors in ghci, and is
+-- useful for using with other libraries and functions that expect sized
+-- vectors in an interactive setting.
+--
+-- (Note that as of GHC 8.6, you cannot get the @n@ in scope in your ghci
+-- session using ScopedTypeVariables, like you can with do blocks)
+--
+-- Note that due to quirks in GHC pattern synonym completeness checking,
+-- you will get incomplete pattern matches if you use this polymorphically
+-- over different vector types, or you use any vector type other than the
+-- three supported by this library (normal, storable, unboxed).
+pattern SomeVector
+    :: VG.Vector v a
+    => forall n. KnownNat n
+    => Vector v n a
+    -> v a
+pattern SomeVector v <- ((`withSized` SV_) -> SV_ v)
+  where
+    SomeVector v = fromSized v
+{-# complete SomeVector :: Boxed.Vector    #-}
+{-# complete SomeVector :: Unboxed.Vector  #-}
+{-# complete SomeVector :: Storable.Vector #-}
 
 instance (VG.Vector v a, Num a, KnownNat n) => Num (Vector v n a) where
     (+)         = zipWith (+)

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -1837,6 +1837,13 @@ data SV_ v a = forall n. KnownNat n => SV_ (Vector v n a)
 -- (Note that as of GHC 8.6, you cannot get the @n@ in scope in your ghci
 -- session using ScopedTypeVariables, like you can with do blocks)
 --
+-- You can also use this as a constructor, to take a sized vector and
+-- "hide" the size, to produce an unsized vector:
+--
+-- @
+-- SomeVector :: Sized.Vector n a -> Unsized.Vector a
+-- @
+--
 -- Note that due to quirks in GHC pattern synonym completeness checking,
 -- you will get incomplete pattern matches if you use this polymorphically
 -- over different vector types, or you use any vector type other than the

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -33,7 +33,7 @@ not exported.
 -}
 
 module Data.Vector.Generic.Sized
-  ( Vector(SomeVector)
+  ( Vector(SomeSized)
   , MVector
    -- * Accessors
    -- ** Length information
@@ -1765,7 +1765,7 @@ withVectorUnsafe :: (v a -> w b) -> Vector v n a -> Vector w n b
 withVectorUnsafe f (Vector v) = Vector (f v)
 {-# inline withVectorUnsafe #-}
 
--- | Internal existential wrapper used for implementing 'SomeVector'
+-- | Internal existential wrapper used for implementing 'SomeSized'
 -- pattern synonym
 data SV_ v a = forall n. KnownNat n => SV_ (Vector v n a)
 
@@ -1775,7 +1775,7 @@ data SV_ v a = forall n. KnownNat n => SV_ (Vector v n a)
 --
 -- @
 -- testFunc :: Unsized.Vector Int -> Int
--- testFunc ('SomeVector' v) =
+-- testFunc ('SomeSized' v) =
 --     'sum' ('zipWith' (+) v ('replicate' 1))
 --         -- ^ here, v is `Sized.Vector n Int`, and we have
 --                     `'KnownNat' n`
@@ -1784,7 +1784,7 @@ data SV_ v a = forall n. KnownNat n => SV_ (Vector v n a)
 -- The @n@ type variable will be properly instantiated to whatever the
 -- length of the vector is, and you will also have a @'KnownNat' n@
 -- instance available.  You can get @n@ in scope by turning on
--- ScopedTypeVariables and matching on @'SomeVector' (v :: Sized.Vector
+-- ScopedTypeVariables and matching on @'SomeSized' (v :: Sized.Vector
 -- n Int)@.
 --
 -- Without this, you would otherwise have to use 'withSized' to do the same
@@ -1811,11 +1811,11 @@ data SV_ v a = forall n. KnownNat n => SV_ (Vector v n a)
 --
 -- main :: IO ()
 -- main = do
---     SomeVector v <- getAVector -- v is `Sized.Vector n Int`
+--     SomeSized v <- getAVector -- v is `Sized.Vector n Int`
 --     print v
 --
 --     -- alternatively, get n in scope
---     SomeVector (v2 :: Sized.Vector n Int) <- getAVector
+--     SomeSized (v2 :: Sized.Vector n Int) <- getAVector
 --     print v2
 -- @
 --
@@ -1826,7 +1826,7 @@ data SV_ v a = forall n. KnownNat n => SV_ (Vector v n a)
 -- from unsized vectors.
 --
 -- @
--- ghci> SomeVector v <- pure (myUnsizedVector :: Unsized.Vector Int)
+-- ghci> SomeSized v <- pure (myUnsizedVector :: Unsized.Vector Int)
 --              -- ^ v is `Sized.Vector n Int`
 -- @
 --
@@ -1841,24 +1841,24 @@ data SV_ v a = forall n. KnownNat n => SV_ (Vector v n a)
 -- "hide" the size, to produce an unsized vector:
 --
 -- @
--- SomeVector :: Sized.Vector n a -> Unsized.Vector a
+-- SomeSized :: Sized.Vector n a -> Unsized.Vector a
 -- @
 --
 -- Note that due to quirks in GHC pattern synonym completeness checking,
 -- you will get incomplete pattern matches if you use this polymorphically
 -- over different vector types, or you use any vector type other than the
 -- three supported by this library (normal, storable, unboxed).
-pattern SomeVector
+pattern SomeSized
     :: VG.Vector v a
     => forall n. KnownNat n
     => Vector v n a
     -> v a
-pattern SomeVector v <- ((`withSized` SV_) -> SV_ v)
+pattern SomeSized v <- ((`withSized` SV_) -> SV_ v)
   where
-    SomeVector v = fromSized v
-{-# complete SomeVector :: Boxed.Vector    #-}
-{-# complete SomeVector :: Unboxed.Vector  #-}
-{-# complete SomeVector :: Storable.Vector #-}
+    SomeSized v = fromSized v
+{-# complete SomeSized :: Boxed.Vector    #-}
+{-# complete SomeSized :: Unboxed.Vector  #-}
+{-# complete SomeSized :: Storable.Vector #-}
 
 instance (VG.Vector v a, Num a, KnownNat n) => Num (Vector v n a) where
     (+)         = zipWith (+)

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -24,7 +24,7 @@ not exported.
 
 module Data.Vector.Sized
  ( Vector
-  , pattern SomeVector
+  , pattern SomeSized
   , VM.MVector
    -- * Accessors
    -- ** Length information
@@ -1534,7 +1534,7 @@ withVectorUnsafe = V.withVectorUnsafe
 --
 -- @
 -- testFunc :: Unsized.Vector Int -> Int
--- testFunc ('SomeVector' v) =
+-- testFunc ('SomeSized' v) =
 --     'sum' ('zipWith' (+) v ('replicate' 1))
 --         -- ^ here, v is `Sized.Vector n Int`, and we have
 --                     `'KnownNat' n`
@@ -1543,7 +1543,7 @@ withVectorUnsafe = V.withVectorUnsafe
 -- The @n@ type variable will be properly instantiated to whatever the
 -- length of the vector is, and you will also have a @'KnownNat' n@
 -- instance available.  You can get @n@ in scope by turning on
--- ScopedTypeVariables and matching on @'SomeVector' (v :: Sized.Vector
+-- ScopedTypeVariables and matching on @'SomeSized' (v :: Sized.Vector
 -- n Int)@.
 --
 -- Without this, you would otherwise have to use 'withSized' to do the same
@@ -1570,9 +1570,9 @@ withVectorUnsafe = V.withVectorUnsafe
 --
 -- main :: IO ()
 -- main = do
---     SomeVector v <- getAVector -- v is `Sized.Vector n Int`
+--     SomeSized v <- getAVector -- v is `Sized.Vector n Int`
 --     -- get n in scope
---     SomeVector (v :: Sized.Vector n Int) <- getAVector
+--     SomeSized (v :: Sized.Vector n Int) <- getAVector
 --     print v
 -- @
 --
@@ -1583,7 +1583,7 @@ withVectorUnsafe = V.withVectorUnsafe
 -- from unsized vectors.
 --
 -- @
--- ghci> SomeVector v <- pure (myUnsizedVector :: Unsized.Vector Int)
+-- ghci> SomeSized v <- pure (myUnsizedVector :: Unsized.Vector Int)
 --              -- ^ v is `Sized.Vector n Int`
 -- @
 --
@@ -1598,8 +1598,8 @@ withVectorUnsafe = V.withVectorUnsafe
 -- "hide" the size, to produce an unsized vector:
 --
 -- @
--- SomeVector :: Sized.Vector n a -> Unsized.Vector a
+-- SomeSized :: Sized.Vector n a -> Unsized.Vector a
 -- @
-pattern SomeVector :: () => KnownNat n => Vector n a -> VU.Vector a
-pattern SomeVector v = V.SomeVector v
-{-# complete SomeVector #-}
+pattern SomeSized :: () => KnownNat n => Vector n a -> VU.Vector a
+pattern SomeSized v = V.SomeSized v
+{-# complete SomeSized #-}

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE CPP                        #-}
 
 #if MIN_VERSION_base(4,12,0)
@@ -23,6 +24,7 @@ not exported.
 
 module Data.Vector.Sized
  ( Vector
+  , pattern SomeVector
   , VM.MVector
    -- * Accessors
    -- ** Length information
@@ -1525,3 +1527,72 @@ fromSized = V.fromSized
 withVectorUnsafe :: (VU.Vector a -> VU.Vector b) -> Vector n a -> Vector n b
 withVectorUnsafe = V.withVectorUnsafe
 {-# inline withVectorUnsafe #-}
+
+-- | Pattern synonym that lets you treat an unsized vector as if it
+-- "contained" a sized vector.  If you pattern match on an unsized vector,
+-- its contents will be the /sized/ vector counterpart.
+--
+-- @
+-- testFunc :: Unsized.Vector Int -> Int
+-- testFunc ('SomeVector' v) =
+--     'sum' ('zipWith' (+) v ('replicate' 1))
+--         -- ^ here, v is `Sized.Vector n Int`, and we have
+--                     `'KnownNat' n`
+-- @
+--
+-- The @n@ type variable will be properly instantiated to whatever the
+-- length of the vector is, and you will also have a @'KnownNat' n@
+-- instance available.  You can get @n@ in scope by turning on
+-- ScopedTypeVariables and matching on @'SomeVector' (v :: Sized.Vector
+-- n Int)@.
+--
+-- Without this, you would otherwise have to use 'withSized' to do the same
+-- thing:
+--
+-- @
+-- testFunc :: Unsized.Vector Int -> Int
+-- testFunc u = 'withSized' u $ \\v ->
+--     'sum' ('zipWith' (+) v ('replicate' 1))
+-- @
+--
+-- Remember that the type of final result of your function (the @Int@,
+-- here) must /not/ depend on @n@.  However, the types of the intermediate
+-- values are allowed to depend on @n@.
+--
+-- This is /especially/ useful in do blocks, where you can pattern match on
+-- the unsized results of actions, to use the sized vector in the rest of
+-- the do block.  You also get a @'KnownNat' n@ constraint for the
+-- remainder of the do block.
+--
+-- @
+-- -- If you had:
+-- getAVector :: IO (Unsized.Vector Int)
+--
+-- main :: IO ()
+-- main = do
+--     SomeVector v <- getAVector -- v is `Sized.Vector n Int`
+--     -- get n in scope
+--     SomeVector (v :: Sized.Vector n Int) <- getAVector
+--     print v
+-- @
+--
+-- Remember that the final type of the result of the do block ('()', here)
+-- must not depend on @n@.  However, the 
+--
+-- Also useful in ghci, where you can pattern match to get sized vectors
+-- from unsized vectors.
+--
+-- @
+-- ghci> SomeVector v <- pure (myUnsizedVector :: Unsized.Vector Int)
+--              -- ^ v is `Sized.Vector n Int`
+-- @
+--
+-- This enables interactive exploration with sized vectors in ghci, and is
+-- useful for using with other libraries and functions that expect sized
+-- vectors in an interactive setting.
+--
+-- (Note that as of GHC 8.6, you cannot get the @n@ in scope in your ghci
+-- session using ScopedTypeVariables, like you can with do blocks)
+pattern SomeVector :: () => KnownNat n => Vector n a -> VU.Vector a
+pattern SomeVector v = V.SomeVector v
+{-# complete SomeVector #-}

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -1593,6 +1593,13 @@ withVectorUnsafe = V.withVectorUnsafe
 --
 -- (Note that as of GHC 8.6, you cannot get the @n@ in scope in your ghci
 -- session using ScopedTypeVariables, like you can with do blocks)
+--
+-- You can also use this as a constructor, to take a sized vector and
+-- "hide" the size, to produce an unsized vector:
+--
+-- @
+-- SomeVector :: Sized.Vector n a -> Unsized.Vector a
+-- @
 pattern SomeVector :: () => KnownNat n => Vector n a -> VU.Vector a
 pattern SomeVector v = V.SomeVector v
 {-# complete SomeVector #-}

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE CPP                 #-}
 
 #if MIN_VERSION_base(4,12,0)
@@ -24,6 +25,7 @@ not exported.
 
 module Data.Vector.Storable.Sized
  ( Vector
+  , pattern SomeVector
   , VSM.MVector
    -- * Accessors
    -- ** Length information
@@ -1601,3 +1603,71 @@ withVectorUnsafe :: forall a b (n :: Nat). ()
 withVectorUnsafe = V.withVectorUnsafe
 {-# inline withVectorUnsafe #-}
 
+-- | Pattern synonym that lets you treat an unsized vector as if it
+-- "contained" a sized vector.  If you pattern match on an unsized vector,
+-- its contents will be the /sized/ vector counterpart.
+--
+-- @
+-- testFunc :: Unsized.Vector Int -> Int
+-- testFunc ('SomeVector' v) =
+--     'sum' ('zipWith' (+) v ('replicate' 1))
+--         -- ^ here, v is `Sized.Vector n Int`, and we have
+--                     `'KnownNat' n`
+-- @
+--
+-- The @n@ type variable will be properly instantiated to whatever the
+-- length of the vector is, and you will also have a @'KnownNat' n@
+-- instance available.  You can get @n@ in scope by turning on
+-- ScopedTypeVariables and matching on @'SomeVector' (v :: Sized.Vector
+-- n Int)@.
+--
+-- Without this, you would otherwise have to use 'withSized' to do the same
+-- thing:
+--
+-- @
+-- testFunc :: Unsized.Vector Int -> Int
+-- testFunc u = 'withSized' u $ \\v ->
+--     'sum' ('zipWith' (+) v ('replicate' 1))
+-- @
+--
+-- Remember that the type of final result of your function (the @Int@,
+-- here) must /not/ depend on @n@.  However, the types of the intermediate
+-- values are allowed to depend on @n@.
+--
+-- This is /especially/ useful in do blocks, where you can pattern match on
+-- the unsized results of actions, to use the sized vector in the rest of
+-- the do block.  You also get a @'KnownNat' n@ constraint for the
+-- remainder of the do block.
+--
+-- @
+-- -- If you had:
+-- getAVector :: IO (Unsized.Vector Int)
+--
+-- main :: IO ()
+-- main = do
+--     SomeVector v <- getAVector -- v is `Sized.Vector n Int`
+--     -- get n in scope
+--     SomeVector (v :: Sized.Vector n Int) <- getAVector
+--     print v
+-- @
+--
+-- Remember that the final type of the result of the do block ('()', here)
+-- must not depend on @n@.  However, the 
+--
+-- Also useful in ghci, where you can pattern match to get sized vectors
+-- from unsized vectors.
+--
+-- @
+-- ghci> SomeVector v <- pure (myUnsizedVector :: Unsized.Vector Int)
+--              -- ^ v is `Sized.Vector n Int`
+-- @
+--
+-- This enables interactive exploration with sized vectors in ghci, and is
+-- useful for using with other libraries and functions that expect sized
+-- vectors in an interactive setting.
+--
+-- (Note that as of GHC 8.6, you cannot get the @n@ in scope in your ghci
+-- session using ScopedTypeVariables, like you can with do blocks)
+pattern SomeVector :: Storable a => KnownNat n => Vector n a -> VS.Vector a
+pattern SomeVector v = V.SomeVector v
+{-# complete SomeVector #-}

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -25,7 +25,7 @@ not exported.
 
 module Data.Vector.Storable.Sized
  ( Vector
-  , pattern SomeVector
+  , pattern SomeSized
   , VSM.MVector
    -- * Accessors
    -- ** Length information
@@ -1609,7 +1609,7 @@ withVectorUnsafe = V.withVectorUnsafe
 --
 -- @
 -- testFunc :: Unsized.Vector Int -> Int
--- testFunc ('SomeVector' v) =
+-- testFunc ('SomeSized' v) =
 --     'sum' ('zipWith' (+) v ('replicate' 1))
 --         -- ^ here, v is `Sized.Vector n Int`, and we have
 --                     `'KnownNat' n`
@@ -1618,7 +1618,7 @@ withVectorUnsafe = V.withVectorUnsafe
 -- The @n@ type variable will be properly instantiated to whatever the
 -- length of the vector is, and you will also have a @'KnownNat' n@
 -- instance available.  You can get @n@ in scope by turning on
--- ScopedTypeVariables and matching on @'SomeVector' (v :: Sized.Vector
+-- ScopedTypeVariables and matching on @'SomeSized' (v :: Sized.Vector
 -- n Int)@.
 --
 -- Without this, you would otherwise have to use 'withSized' to do the same
@@ -1645,9 +1645,9 @@ withVectorUnsafe = V.withVectorUnsafe
 --
 -- main :: IO ()
 -- main = do
---     SomeVector v <- getAVector -- v is `Sized.Vector n Int`
+--     SomeSized v <- getAVector -- v is `Sized.Vector n Int`
 --     -- get n in scope
---     SomeVector (v :: Sized.Vector n Int) <- getAVector
+--     SomeSized (v :: Sized.Vector n Int) <- getAVector
 --     print v
 -- @
 --
@@ -1658,7 +1658,7 @@ withVectorUnsafe = V.withVectorUnsafe
 -- from unsized vectors.
 --
 -- @
--- ghci> SomeVector v <- pure (myUnsizedVector :: Unsized.Vector Int)
+-- ghci> SomeSized v <- pure (myUnsizedVector :: Unsized.Vector Int)
 --              -- ^ v is `Sized.Vector n Int`
 -- @
 --
@@ -1673,8 +1673,8 @@ withVectorUnsafe = V.withVectorUnsafe
 -- "hide" the size, to produce an unsized vector:
 --
 -- @
--- SomeVector :: Sized.Vector n a -> Unsized.Vector a
+-- SomeSized :: Sized.Vector n a -> Unsized.Vector a
 -- @
-pattern SomeVector :: Storable a => KnownNat n => Vector n a -> VS.Vector a
-pattern SomeVector v = V.SomeVector v
-{-# complete SomeVector #-}
+pattern SomeSized :: Storable a => KnownNat n => Vector n a -> VS.Vector a
+pattern SomeSized v = V.SomeSized v
+{-# complete SomeSized #-}

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -1668,6 +1668,13 @@ withVectorUnsafe = V.withVectorUnsafe
 --
 -- (Note that as of GHC 8.6, you cannot get the @n@ in scope in your ghci
 -- session using ScopedTypeVariables, like you can with do blocks)
+--
+-- You can also use this as a constructor, to take a sized vector and
+-- "hide" the size, to produce an unsized vector:
+--
+-- @
+-- SomeVector :: Sized.Vector n a -> Unsized.Vector a
+-- @
 pattern SomeVector :: Storable a => KnownNat n => Vector n a -> VS.Vector a
 pattern SomeVector v = V.SomeVector v
 {-# complete SomeVector #-}

--- a/src/Data/Vector/Unboxed/Sized.hs
+++ b/src/Data/Vector/Unboxed/Sized.hs
@@ -1667,6 +1667,13 @@ withVectorUnsafe = V.withVectorUnsafe
 --
 -- (Note that as of GHC 8.6, you cannot get the @n@ in scope in your ghci
 -- session using ScopedTypeVariables, like you can with do blocks)
+--
+-- You can also use this as a constructor, to take a sized vector and
+-- "hide" the size, to produce an unsized vector:
+--
+-- @
+-- SomeVector :: Sized.Vector n a -> Unsized.Vector a
+-- @
 pattern SomeVector :: Unbox a => KnownNat n => Vector n a -> VU.Vector a
 pattern SomeVector v = V.SomeVector v
 {-# complete SomeVector #-}

--- a/src/Data/Vector/Unboxed/Sized.hs
+++ b/src/Data/Vector/Unboxed/Sized.hs
@@ -25,7 +25,7 @@ not exported.
 
 module Data.Vector.Unboxed.Sized
  ( Vector
-  , pattern SomeVector
+  , pattern SomeSized
   , VUM.MVector
    -- * Accessors
    -- ** Length information
@@ -1608,7 +1608,7 @@ withVectorUnsafe = V.withVectorUnsafe
 --
 -- @
 -- testFunc :: Unsized.Vector Int -> Int
--- testFunc ('SomeVector' v) =
+-- testFunc ('SomeSized' v) =
 --     'sum' ('zipWith' (+) v ('replicate' 1))
 --         -- ^ here, v is `Sized.Vector n Int`, and we have
 --                     `'KnownNat' n`
@@ -1617,7 +1617,7 @@ withVectorUnsafe = V.withVectorUnsafe
 -- The @n@ type variable will be properly instantiated to whatever the
 -- length of the vector is, and you will also have a @'KnownNat' n@
 -- instance available.  You can get @n@ in scope by turning on
--- ScopedTypeVariables and matching on @'SomeVector' (v :: Sized.Vector
+-- ScopedTypeVariables and matching on @'SomeSized' (v :: Sized.Vector
 -- n Int)@.
 --
 -- Without this, you would otherwise have to use 'withSized' to do the same
@@ -1644,9 +1644,9 @@ withVectorUnsafe = V.withVectorUnsafe
 --
 -- main :: IO ()
 -- main = do
---     SomeVector v <- getAVector -- v is `Sized.Vector n Int`
+--     SomeSized v <- getAVector -- v is `Sized.Vector n Int`
 --     -- get n in scope
---     SomeVector (v :: Sized.Vector n Int) <- getAVector
+--     SomeSized (v :: Sized.Vector n Int) <- getAVector
 --     print v
 -- @
 --
@@ -1657,7 +1657,7 @@ withVectorUnsafe = V.withVectorUnsafe
 -- from unsized vectors.
 --
 -- @
--- ghci> SomeVector v <- pure (myUnsizedVector :: Unsized.Vector Int)
+-- ghci> SomeSized v <- pure (myUnsizedVector :: Unsized.Vector Int)
 --              -- ^ v is `Sized.Vector n Int`
 -- @
 --
@@ -1672,8 +1672,8 @@ withVectorUnsafe = V.withVectorUnsafe
 -- "hide" the size, to produce an unsized vector:
 --
 -- @
--- SomeVector :: Sized.Vector n a -> Unsized.Vector a
+-- SomeSized :: Sized.Vector n a -> Unsized.Vector a
 -- @
-pattern SomeVector :: Unbox a => KnownNat n => Vector n a -> VU.Vector a
-pattern SomeVector v = V.SomeVector v
-{-# complete SomeVector #-}
+pattern SomeSized :: Unbox a => KnownNat n => Vector n a -> VU.Vector a
+pattern SomeSized v = V.SomeSized v
+{-# complete SomeSized #-}


### PR DESCRIPTION
Adds the `SomeSized` pattern synonym.  It lets you treat an unsized vector as a "wrapped" sized vector.  You can write things like:

```haskell
myFunc :: Unsized.Vector Int -> Int
myFunc (SomeSized v) = sum $ zipWith (+) v (replicate 1)
```

`v` there will become a `Sized.Vector n Int`, and we also have `KnownNat n` to use in the function body. (We can get `n` in scope as well, with ScopedTypeVariables and giving a type annotation for `v`)

We would normally have to write:

```haskell
myFunc :: Unsized.Vector Int -> Int
myFunc u = withSized u $ \v -> sum $ zipWith (+) v (replicate 1)
```

The real big/practical use case for this, I think, is in do blocks, were you can directly bind a sized vector from the result of an action returning an unsized vector, and you can directly use that sized vector for the rest of the do block, with `KnownNat n` as well:

```haskell
-- suppose you had:
getVector :: IO (Unsized.Vector Int)

-- then you can do:
main :: IO ()
main = do
    SomeSized v1 <- getVector
    SomeSized v2 <- getVector
    print v1
    print v2      -- v1, v2 are sized vectors, and we have KnownNat for their lengths
```

To me this is a huge QoL improvement over what we had to do before:

```haskell
main :: IO ()
main = do
    u1 <- getVector
    u2 <- getVector
    withSized u1 $ \v1 ->
      withSized u2 $ \v2 ->
        print v1
        print v2
```

which requires a nested continuations.

Furthermore, I think this really opens the door for interactive exploratory development with sized vectors in ghci, which was always pretty awkward before.  We can do:

```haskell
ghci> SomeSized v <- pure (myUnsizedVector :: Unsized.Vector Int)
```

and we now have `v :: Sized.Vector n Int` in scope that we can use interactively.  This is something that we couldn't really do before in ghci in a way that wasn't really awkward (like explicitly finding out the length and using `toSized` and matching on `Just`, or writing a throwaway existential).

I think that this opens up vector-sized to the interactive/exploratory development world (along with all libraries that use vector-sized), which was previously more or less out of reach without awkward workarounds.  

Some caveats:

*   Unfortunately, there is no way to use ScopedTypeVariables (as far as I know) to match on the length type when using *in ghci*.  However, it's still possible in normal do blocks.
*    Due to how pattern synonym exhaustiveness checking works, we can't suppress an incomplete pattern match warnings when using `SomeSized` from *Data.Vector.Generic.Sized* *generically* over different vector types.  However, we can properly suppress incomplete pattern match warnings when using it with *specific* vector types, or with the specific monomorphic `SomeSized` patterns from *Data.Vector.Sized* etc.