### PR TITLE
bump upper bound on primitive to 0.8

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,7 @@ dependencies:
  - vector >=0.11 && <0.13
  - deepseq >=1.1 && <1.5
  - finite-typelits >=0.1
- - primitive >=0.5 && <0.7
+ - primitive >=0.5 && <0.8
  - indexed-list-literals >=0.2.0.0
  - adjunctions >=4.3 && <4.5
  - distributive >=0.5 && <0.7

--- a/vector-sized.cabal
+++ b/vector-sized.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 50da9569c820fc86ede84aaca55d7de4728667ef100736b69d5e446b12390f6a
+-- hash: 9bd3e344ed95be9e3519cde9a9a6de54ee969524b9403d2a9fb2af6893b506bd
 
 name:           vector-sized
 version:        1.2.0.0
@@ -54,6 +54,6 @@ library
     , finite-typelits >=0.1
     , hashable >=1.2.4.0 && <1.3
     , indexed-list-literals >=0.2.0.0
-    , primitive >=0.5 && <0.7
+    , primitive >=0.5 && <0.8
     , vector >=0.11 && <0.13
   default-language: Haskell2010


### PR DESCRIPTION
Should address https://github.com/commercialhaskell/stackage/issues/4564 :)  Things appear to build correctly.

Note that this could also be achieved using a hackage metadata change if you want to fix this without uploading a new version.