### PR TITLE
Add unidirectional patterns for immutable vectors (#85)

### DIFF
--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -55,6 +55,12 @@ module Data.Vector.Sized
   , drop'
   , splitAt
   , splitAt'
+  , uncons
+  , unsnoc
+  -- ** Pattern synonyms
+  , pattern Empty
+  , pattern (:<|)
+  , pattern (:|>)
     -- * Construction
     -- ** Initialization
   , empty
@@ -454,6 +460,35 @@ splitAt' :: forall n m a p. KnownNat n
          => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
+
+-- | /O(1)/ Yield the 'head' and 'tail' elements of a non-empty vector.
+uncons :: forall n a. Vector (1 + n) a -> (a, Vector n a)
+uncons = V.uncons
+
+-- | /O(1)/ Yield the 'init' and 'last' elements of a non-empty vector.
+unsnoc :: forall n a. Vector (n + 1) a -> (Vector n a, a)
+unsnoc = V.unsnoc
+
+--------------------------------------------------------------------------------
+-- ** Pattern synonyms
+--------------------------------------------------------------------------------
+
+-- | /O(1)/ Pattern match on a vector of zero length.
+pattern Empty :: Vector 0 a
+pattern Empty <- _
+{-# COMPLETE Empty #-}
+
+infixr 5 :<|
+-- | /O(1)/ Pattern match on the 'head' and 'tail' elements of a non-empty vector.
+pattern (:<|) :: a -> Vector n a -> Vector (1 + n) a
+pattern h :<| t <- h V.:<| t
+{-# COMPLETE (:<|) #-}
+
+infixl 5 :|>
+-- | /O(1)/ Pattern match on the 'init' and 'last' elements of a non-empty vector.
+pattern (:|>) :: Vector n a -> a -> Vector (n + 1) a
+pattern i :|> l <- i V.:|> l
+{-# COMPLETE (:|>) #-}
 
 --------------------------------------------------------------------------------
 -- * Construction

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -56,6 +56,12 @@ module Data.Vector.Storable.Sized
   , drop'
   , splitAt
   , splitAt'
+  , uncons
+  , unsnoc
+  -- ** Pattern synonyms
+  , pattern Empty
+  , pattern (:<|)
+  , pattern (:|>)
     -- * Construction
     -- ** Initialization
   , empty
@@ -461,6 +467,37 @@ splitAt' :: forall n m a p. (KnownNat n, Storable a)
          => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
+
+-- | /O(1)/ Yield the 'head' and 'tail' elements of a non-empty vector.
+uncons :: forall n a. Storable a
+       => Vector (1 + n) a -> (a, Vector n a)
+uncons = V.uncons
+
+-- | /O(1)/ Yield the 'init' and 'last' elements of a non-empty vector.
+unsnoc :: forall n a. Storable a
+       => Vector (n + 1) a -> (Vector n a, a)
+unsnoc = V.unsnoc
+
+--------------------------------------------------------------------------------
+-- ** Pattern synonyms
+--------------------------------------------------------------------------------
+
+-- | /O(1)/ Pattern match on a vector of zero length.
+pattern Empty :: Storable a => Vector 0 a
+pattern Empty <- _
+{-# COMPLETE Empty #-}
+
+infixr 5 :<|
+-- | /O(1)/ Pattern match on the 'head' and 'tail' elements of a non-empty vector.
+pattern (:<|) :: Storable a => a -> Vector n a -> Vector (1 + n) a
+pattern h :<| t <- h V.:<| t
+{-# COMPLETE (:<|) #-}
+
+infixl 5 :|>
+-- | /O(1)/ Pattern match on the 'init' and 'last' elements of a non-empty vector.
+pattern (:|>) :: Storable a => Vector n a -> a -> Vector (n + 1) a
+pattern i :|> l <- i V.:|> l
+{-# COMPLETE (:|>) #-}
 
 --------------------------------------------------------------------------------
 -- * Construction

--- a/src/Data/Vector/Unboxed/Sized.hs
+++ b/src/Data/Vector/Unboxed/Sized.hs
@@ -56,6 +56,12 @@ module Data.Vector.Unboxed.Sized
   , drop'
   , splitAt
   , splitAt'
+  , uncons
+  , unsnoc
+  -- ** Pattern synonyms
+  , pattern Empty
+  , pattern (:<|)
+  , pattern (:|>)
     -- * Construction
     -- ** Initialization
   , empty
@@ -462,6 +468,37 @@ splitAt' :: forall n m a p. (KnownNat n, Unbox a)
          => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
+
+-- | /O(1)/ Yield the 'head' and 'tail' elements of a non-empty vector.
+uncons :: forall n a. Unbox a
+       => Vector (1 + n) a -> (a, Vector n a)
+uncons = V.uncons
+
+-- | /O(1)/ Yield the 'init' and 'last' elements of a non-empty vector.
+unsnoc :: forall n a. Unbox a
+       => Vector (n + 1) a -> (Vector n a, a)
+unsnoc = V.unsnoc
+
+--------------------------------------------------------------------------------
+-- ** Pattern synonyms
+--------------------------------------------------------------------------------
+
+-- | /O(1)/ Pattern match on a vector of zero length.
+pattern Empty :: Unbox a => Vector 0 a
+pattern Empty <- _
+{-# COMPLETE Empty #-}
+
+infixr 5 :<|
+-- | /O(1)/ Pattern match on the 'head' and 'tail' elements of a non-empty vector.
+pattern (:<|) :: Unbox a => a -> Vector n a -> Vector (1 + n) a
+pattern h :<| t <- h V.:<| t
+{-# COMPLETE (:<|) #-}
+
+infixl 5 :|>
+-- | /O(1)/ Pattern match on the 'init' and 'last' elements of a non-empty vector.
+pattern (:|>) :: Unbox a => Vector n a -> a -> Vector (n + 1) a
+pattern i :|> l <- i V.:|> l
+{-# COMPLETE (:|>) #-}
 
 --------------------------------------------------------------------------------
 -- * Construction


### PR DESCRIPTION
* Define pattern synonyms

  - `Empty` for matching on zero length vectors
  - `:<|` for matching on the head and tail of a non-empty vector
  - `:|>` for matching on the init and last of a non-empty vector

  in `Vector.Generic.Sized` mimicking `Data.Sequence`.

* Additionally export helpers `snoc` and `unsnoc`.

* Re-export specialised versions from

  - `Vector.Sized`
  - `Vector.Unboxed.Sized`
  - `Vector.Storable.Sized`