### PR TITLE
ghc 8.10 compatibility

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 #if MIN_VERSION_base(4,12,0)
 {-# LANGUAGE NoStarIsType #-}


### PR DESCRIPTION
Small fix for GHC 8.10: the recursive use of the `VG.Mutable` type family in the equation

```haskell
type instance VG.Mutable (Vector v n) = MVector (VG.Mutable v) n
```
causes the injectivity annotation on `VG.Mutable` to be rejected unless the `UndecidableInstances` extension is enabled.    

With this fix the library builds successfully with `GHC 8.10 rc1` on my machine.