### PR TITLE
Safe construction of vectors from linked lists of statically known size

### DIFF
--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -60,6 +60,8 @@ module Data.Vector.Sized
   , empty
   , singleton
   , fromTuple
+  , BuildVector(..)
+  , pattern Build
   , replicate
   , replicate'
   , generate
@@ -238,6 +240,7 @@ module Data.Vector.Sized
   ) where
 
 import qualified Data.Vector.Generic.Sized as V
+import Data.Vector.Generic.Sized ( BuildVector(..) )
 import qualified Data.Vector as VU
 import qualified Data.Vector.Mutable.Sized as VM
 import GHC.TypeLits
@@ -473,7 +476,7 @@ singleton :: forall a. a -> Vector 1 a
 singleton = V.singleton
 {-# inline singleton #-}
 
--- | /O(n)/ Construct a vector in a type safe manner.
+-- | /O(n)/ Construct a vector in a type safe manner using a tuple.
 -- @
 --   fromTuple (1,2) :: Vector 2 Int
 --   fromTuple ("hey", "what's", "going", "on") :: Vector 4 String
@@ -482,6 +485,15 @@ fromTuple :: forall input length ty.
              (IndexedListLiterals input length ty, KnownNat length)
           => input -> Vector length ty
 fromTuple = V.fromTuple
+
+-- | /O(n)/ Construct a vector in a type-safe manner using a sized linked list.
+-- @
+--   Build (1 :< 2 :< 3 :< Nil) :: Vector 3 Int
+--   Build ("not" :< "much" :< Nil) :: Vector 2 String
+-- @
+-- Can also be used as a pattern.
+pattern Build :: V.BuildVector n a -> Vector n a
+pattern Build build = V.Build build
 
 -- | /O(n)/ Construct a vector with the same element in each position where the
 -- length is inferred from the type.

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -61,6 +61,7 @@ module Data.Vector.Storable.Sized
   , empty
   , singleton
   , fromTuple
+  , pattern Build
   , replicate
   , replicate'
   , generate
@@ -482,7 +483,7 @@ singleton :: forall a. (Storable a)
 singleton = V.singleton
 {-# inline singleton #-}
 
--- | /O(n)/ Construct a vector in a type safe manner
+-- | /O(n)/ Construct a vector in a type safe manner using a tuple.
 -- @
 --   fromTuple (1,2) :: Vector 2 Int
 --   fromTuple ("hey", "what's", "going", "on") :: Vector 4 String
@@ -492,6 +493,15 @@ fromTuple :: forall a input length.
           => input -> Vector length a
 fromTuple = V.fromTuple
 {-# inline fromTuple #-}
+
+-- | /O(n)/ Construct a vector in a type-safe manner using a sized linked list.
+-- @
+--   Build (1 :< 2 :< 3 :< Nil) :: Vector 3 Int
+--   Build ("not" :< "much" :< Nil) :: Vector 2 String
+-- @
+-- Can also be used as a pattern.
+pattern Build :: Storable a => V.BuildVector n a -> Vector n a
+pattern Build vec = V.Build vec
 
 -- | /O(n)/ Construct a vector with the same element in each position where the
 -- length is inferred from the type.

--- a/src/Data/Vector/Unboxed/Sized.hs
+++ b/src/Data/Vector/Unboxed/Sized.hs
@@ -61,6 +61,7 @@ module Data.Vector.Unboxed.Sized
   , empty
   , singleton
   , fromTuple
+  , pattern Build
   , replicate
   , replicate'
   , generate
@@ -483,7 +484,7 @@ singleton :: forall a. (Unbox a)
 singleton = V.singleton
 {-# inline singleton #-}
 
--- | /O(n)/ Construct a vector in a type safe manner
+-- | /O(n)/ Construct a vector in a type safe manner using a tuple.
 -- @
 --   fromTuple (1,2) :: Vector 2 Int
 --   fromTuple ("hey", "what's", "going", "on") :: Vector 4 String
@@ -493,6 +494,15 @@ fromTuple :: forall a input length.
           => input -> Vector length a
 fromTuple = V.fromTuple
 {-# inline fromTuple #-}
+
+-- | /O(n)/ Construct a vector in a type-safe manner using a sized linked list.
+-- @
+--   Build (1 :< 2 :< 3 :< Nil) :: Vector 3 Int
+--   Build ("not" :< "much" :< Nil) :: Vector 2 String
+-- @
+-- Can also be used as a pattern.
+pattern Build :: Unbox a => V.BuildVector n a -> Vector n a
+pattern Build vec = V.Build vec
 
 -- | /O(n)/ Construct a vector with the same element in each position where the
 -- length is inferred from the type.


### PR DESCRIPTION
Following up on #18 and #85, this PR provides a way to construct vectors from lists in a type safe manner, by defining a linked list data type which is annotated by its length:

```haskell
data BuildVector n a where
  Nil :: BuildVector 0 a
  (:<) :: a -> BuildVector n a -> BuildVector (1 + n) a
```

```haskell
> let v = Build ("a" :< "b" :< "c" :< Nil)
> v
Vector ["a","b","c"] :: Vector 3 String

> Build ( x :< xs ) <- v
> x
"a" :: String
> xs
"b" :< ("c" :< Nil) :: BuildVector 2 String

> let ( w :: Vector 4 Int ) = Build ( 3 :< 2 :< Nil )
-- error:
--    * Couldn't match type `2' with `4'
--      Expected type: BuildVector 4 Int
--        Actual type: BuildVector (1 + 1) Int

> Build ( u1 :< u2 :< u3 :< u_4 :< Nil ) <- v
--    * Couldn't match type `3' with `4'
--      Inaccessible code in
--        a pattern with constructor: V.Nil :: forall a. V.BuildVector 0 a,
--    * In the pattern: V.Nil
--      In the pattern: u_4 V.:< V.Nil
--      In the pattern: u3 V.:< u_4 V.:< V.Nil
```

I think that the sized linked list is the natural data type to use for this purpose. In particular, I find this interface more convenient to use for the creation of vectors from a fixed list of elements than the other interfaces that this library currently provides:
  - `fromList` requires the use of `fromJust`,
  - `withSized` quantifies over the size even though in this case the size is known statically,
  - `fromTuple` is limited to small vectors because of restrictions involving tuples.