### PR TITLE
Implement (Unbox a, KnownNat n) => Unbox (Vector n a)

### DIFF
--- a/src/Data/Vector/Unboxed/Mutable/Sized.hs
+++ b/src/Data/Vector/Unboxed/Mutable/Sized.hs
@@ -483,6 +483,9 @@ fromSized = VGM.fromSized
 {-# inline fromSized #-}
 
 
+-- | This instance allows to define sized matrices and tensors
+-- backed by continuous memory segments, which reduces memory allocations
+-- and relaxes pressure on garbage collector.
 instance (Unbox a, KnownNat n) => Unbox (VG.Vector VS.Vector n a)
 
 newtype instance VSM.MVector s (VG.Vector VS.Vector n a) = MV_Sized (VSM.MVector s a)
@@ -490,44 +493,63 @@ newtype instance VS.Vector     (VG.Vector VS.Vector n a) = V_Sized  (VS.Vector  
 
 instance (Unbox a, KnownNat n) => VM.MVector VSM.MVector (VG.Vector VS.Vector n a) where
   basicLength vs@(MV_Sized v) = VM.basicLength v `quot` intLenM vs
+  {-# inline basicLength #-}
+
   basicUnsafeSlice i n vs@(MV_Sized v) = MV_Sized (VM.basicUnsafeSlice (i * intLenM vs) (n * intLenM vs) v)
+  {-# inline basicUnsafeSlice #-}
+
   basicOverlaps (MV_Sized v1) (MV_Sized v2) = VM.basicOverlaps v1 v2
+  {-# inline basicOverlaps #-}
+
   basicUnsafeNew n = MV_Sized <$> VM.basicUnsafeNew (n * fromIntegral (natVal (Proxy :: Proxy n)))
+  {-# inline basicUnsafeNew #-}
+
   basicInitialize (MV_Sized v) = VM.basicInitialize v
+  {-# inline basicInitialize #-}
+
   basicClear (MV_Sized v) = VM.basicClear v
+  {-# inline basicClear #-}
+
   basicUnsafeCopy (MV_Sized v1) (MV_Sized v2) = VM.basicUnsafeCopy v1 v2
+  {-# inline basicUnsafeCopy #-}
+
   basicUnsafeMove (MV_Sized v1) (MV_Sized v2) = VM.basicUnsafeMove v1 v2
+  {-# inline basicUnsafeMove #-}
+
   basicUnsafeGrow vs@(MV_Sized v) n = MV_Sized <$> VM.basicUnsafeGrow v (n * intLenM vs)
+  {-# inline basicUnsafeGrow #-}
+
   basicUnsafeRead vs@(MV_Sized v) i = Vector <$> V.freeze (VM.basicUnsafeSlice (i * intLenM vs) (intLenM vs) v)
+  {-# inline basicUnsafeRead #-}
+
   basicUnsafeWrite vs@(MV_Sized v) i (Vector x) = V.basicUnsafeCopy (VM.basicUnsafeSlice (i * intLenM vs) (intLenM vs) v) x
-  {-# INLINE basicLength #-}
-  {-# INLINE basicUnsafeSlice #-}
-  {-# INLINE basicOverlaps #-}
-  {-# INLINE basicUnsafeNew #-}
-  {-# INLINE basicInitialize #-}
-  {-# INLINE basicUnsafeRead #-}
-  {-# INLINE basicUnsafeWrite #-}
-  {-# INLINE basicClear #-}
-  {-# INLINE basicUnsafeCopy #-}
-  {-# INLINE basicUnsafeGrow #-}
+  {-# inline basicUnsafeWrite #-}
+
 
 intLenM :: forall s n a. KnownNat n => VSM.MVector s (VG.Vector VS.Vector n a) -> Int
 intLenM _ = fromIntegral (natVal (Proxy :: Proxy n))
 
 instance (Unbox a, KnownNat n) => V.Vector VS.Vector (VG.Vector VS.Vector n a) where
   basicUnsafeFreeze (MV_Sized v) = V_Sized <$> V.basicUnsafeFreeze v
+  {-# inline basicUnsafeFreeze #-}
+
   basicUnsafeThaw (V_Sized v) = MV_Sized <$> V.basicUnsafeThaw v
+  {-# inline basicUnsafeThaw #-}
+
   basicLength vs@(V_Sized v) = V.basicLength v `quot` intLen vs
+  {-# inline basicLength #-}
+
   basicUnsafeSlice i n vs@(V_Sized v) = V_Sized (V.basicUnsafeSlice (i * intLen vs) (n * intLen vs) v)
+  {-# inline basicUnsafeSlice #-}
+
   basicUnsafeCopy (MV_Sized mv) (V_Sized v) = V.basicUnsafeCopy mv v
+  {-# inline basicUnsafeCopy #-}
+
   elemseq _ = seq
+  {-# inline elemseq #-}
+
   basicUnsafeIndexM vs@(V_Sized v) i = pure $! Vector (V.basicUnsafeSlice (i * intLen vs) (intLen vs) v)
-  {-# INLINE basicUnsafeFreeze #-}
-  {-# INLINE basicUnsafeThaw #-}
-  {-# INLINE basicLength #-}
-  {-# INLINE basicUnsafeSlice #-}
-  {-# INLINE basicUnsafeIndexM #-}
-  {-# INLINE elemseq #-}
+  {-# inline basicUnsafeIndexM #-}
 
 intLen :: forall n a. KnownNat n => VS.Vector (VG.Vector VS.Vector n a) -> Int
 intLen _ = fromIntegral (natVal (Proxy :: Proxy n))


### PR DESCRIPTION
Such instance allows to define sized matrices and tensors backed by continuous memory segment, which is important for performance reasons.