### PR TITLE
type-safe lens

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## WIP
 
+## [1.4.4] - 2021-06-26
+
+- Add `ix'`
+
 ## [1.4.3.1] - 2020-12-13
 
 - Fix Bits instance, shiftl and shiftr were incorrect

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: vector-sized
-version: 1.4.3.1
+version: 1.4.4
 synopsis: Size tagged vectors
 description: Please see README.md
 category: Data

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 
 #if MIN_VERSION_base(4,12,0)
 {-# LANGUAGE NoStarIsType #-}
@@ -111,6 +112,7 @@ module Data.Vector.Generic.Sized
   , unsafeBackpermute
     -- * Lenses
   , ix
+  , ix'
   , _head
   , _last
     -- * Elementwise operations
@@ -467,6 +469,14 @@ ix :: forall v n a f. (VG.Vector v a, Functor f)
    => Finite n -> (a -> f a) -> Vector v n a -> f (Vector v n a)
 ix n f vector = (\x -> vector // [(n, x)]) <$> f (index vector n)
 {-# inline ix #-}
+
+-- | Type-safe lens to access (/O(1)/) and update (/O(n)/) an arbitrary element by its index
+-- which should be supplied via TypeApplications.
+ix' :: forall i v n a f. (VG.Vector v a, Functor f,
+  KnownNat i, KnownNat n, i+1 <= n)
+   => (a -> f a) -> Vector v n a -> f (Vector v n a)
+ix' = ix (natToFinite (Proxy::Proxy i))
+{-# inline ix' #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the first element of a non-empty vector.
 _head :: forall v n a f. (VG.Vector v a, Functor f)

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -5,6 +5,9 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE AllowAmbiguousTypes        #-}
 {-# LANGUAGE CPP                        #-}
 
 #if MIN_VERSION_base(4,12,0)
@@ -106,6 +109,7 @@ module Data.Vector.Sized
   , unsafeBackpermute
   -- * Lenses
   , ix
+  , ix'
   , _head
   , _last
     -- * Elementwise operations
@@ -330,6 +334,14 @@ ix :: forall n a f. Functor f
    => Finite n -> (a -> f a) -> Vector n a -> f (Vector n a)
 ix = V.ix
 {-# inline ix #-}
+
+-- | Type-safe lens to access (/O(1)/) and update (/O(n)/) an arbitrary element by its index
+-- which should be supplied via TypeApplications.
+ix' :: forall i n a f. (Functor f,
+  KnownNat i, KnownNat n, i+1 <= n)
+   => (a -> f a) -> Vector n a -> f (Vector n a)
+ix' = V.ix' @i
+{-# inline ix' #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the first element of a non-empty vector.
 _head :: forall n a f. Functor f

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -6,6 +6,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP                 #-}
 
 #if MIN_VERSION_base(4,12,0)
@@ -107,6 +110,7 @@ module Data.Vector.Storable.Sized
   , unsafeBackpermute
     -- * Lenses
   , ix
+  , ix'
   , _head
   , _last
     -- * Elementwise operations
@@ -334,6 +338,14 @@ ix :: forall n a f. (Storable a, Functor f)
    => Finite n -> (a -> f a) -> Vector n a -> f (Vector n a)
 ix = V.ix
 {-# inline ix #-}
+
+-- | Type-safe lens to access (/O(1)/) and update (/O(n)/) an arbitrary element by its index
+-- which should be supplied via TypeApplications.
+ix' :: forall i n a f. (Storable a, Functor f,
+  KnownNat i, KnownNat n, i+1 <= n)
+   => (a -> f a) -> Vector n a -> f (Vector n a)
+ix' = V.ix' @i
+{-# inline ix' #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the first element of a non-empty vector.
 _head :: forall n a f. (Storable a, Functor f)

--- a/src/Data/Vector/Unboxed/Sized.hs
+++ b/src/Data/Vector/Unboxed/Sized.hs
@@ -5,7 +5,10 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP                 #-}
 
 #if MIN_VERSION_base(4,12,0)
@@ -107,6 +110,7 @@ module Data.Vector.Unboxed.Sized
   , unsafeBackpermute
     -- * Lenses
   , ix
+  , ix'
   , _head
   , _last
     -- * Elementwise operations
@@ -336,6 +340,14 @@ ix :: forall n a f. (Unbox a, Functor f)
    => Finite n -> (a -> f a) -> Vector n a -> f (Vector n a)
 ix = V.ix
 {-# inline ix #-}
+
+-- | Type-safe lens to access (/O(1)/) and update (/O(n)/) an arbitrary element by its index
+-- which should be supplied via TypeApplications.
+ix' :: forall i n a f. (Unbox a, Functor f,
+  KnownNat i, KnownNat n, i+1 <= n)
+   => (a -> f a) -> Vector n a -> f (Vector n a)
+ix' = V.ix' @i
+{-# inline ix' #-}
 
 -- | Lens to access (/O(1)/) and update (/O(n)/) the first element of a non-empty vector.
 _head :: forall n a f. (Unbox a, Functor f)

--- a/vector-sized.cabal
+++ b/vector-sized.cabal
@@ -1,11 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: e36af7d31e151c5e8d7ad5636dd5d31b47e82d6fe6384f8f76753ed0e17b61b1
 
 name:           vector-sized
-version:        1.4.3.1
+version:        1.4.4
 synopsis:       Size tagged vectors
 description:    Please see README.md
 category:       Data


### PR DESCRIPTION
Adds type-safe lens (ix') which should be used with TypeAppliactions which makes for terse syntax. Addresses #106.

Example:
```Haskell
let t = fromTuple (1,2,3,4,5) :: Data.Vector.Sized.Vector 5 Int
t ^. ix' @4 -- OK
t ^. ix' @5 -- Doesn't compile
```

I'm not an expert on advanced GHC stuff, so I hope the added GHC language extensions don't affect other things.