### PR TITLE
Changed indexes provided to accum to type-safe Finites.

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -927,9 +927,10 @@ unsafeUpdate_ (Vector v) (Vector is) (Vector w) =
 accum :: VG.Vector v a
       => (a -> b -> a) -- ^ accumulating function @f@
       -> Vector v m a  -- ^ initial vector (of length @m@)
-      -> [(Int,b)]     -- ^ list of index/value pairs (of length @n@)
+      -> [(Finite m,b)]     -- ^ list of index/value pairs (of length @n@)
       -> Vector v m a
-accum f (Vector v) us = Vector (VG.accum f v us)
+accum f (Vector v) us =
+  Vector (VG.accum f v $ (fmap . first) (fromIntegral . getFinite) us)
 {-# inline accum #-}
 
 -- | /O(m+n)/ For each pair @(i,b)@ from the vector of pairs, replace the vector

--- a/src/Data/Vector/Primitive/Sized.hs
+++ b/src/Data/Vector/Primitive/Sized.hs
@@ -706,7 +706,7 @@ unsafeUpdate_ = V.unsafeUpdate_
 accum :: Prim a
       => (a -> b -> a) -- ^ accumulating function @f@
       -> Vector m a  -- ^ initial vector (of length @m@)
-      -> [(Int,b)]     -- ^ list of index/value pairs (of length @n@)
+      -> [(Finite m,b)]     -- ^ list of index/value pairs (of length @n@)
       -> Vector m a
 accum = V.accum
 {-# inline accum #-}

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -741,7 +741,7 @@ unsafeUpdate_ = V.unsafeUpdate_
 -- > accum (+) <5,9,2> [(2,4),(1,6),(0,3),(1,7)] = <5+3, 9+6+7, 2+4>
 accum :: (a -> b -> a) -- ^ accumulating function @f@
       -> Vector m a  -- ^ initial vector (of length @m@)
-      -> [(Int,b)]     -- ^ list of index/value pairs (of length @n@)
+      -> [(Finite m,b)]     -- ^ list of index/value pairs (of length @n@)
       -> Vector m a
 accum = V.accum
 {-# inline accum #-}

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -761,7 +761,7 @@ unsafeUpdate_ = V.unsafeUpdate_
 accum :: Storable a
       => (a -> b -> a) -- ^ accumulating function @f@
       -> Vector m a  -- ^ initial vector (of length @m@)
-      -> [(Int,b)]     -- ^ list of index/value pairs (of length @n@)
+      -> [(Finite m,b)]     -- ^ list of index/value pairs (of length @n@)
       -> Vector m a
 accum = V.accum
 {-# inline accum #-}

--- a/src/Data/Vector/Unboxed/Sized.hs
+++ b/src/Data/Vector/Unboxed/Sized.hs
@@ -762,7 +762,7 @@ unsafeUpdate_ = V.unsafeUpdate_
 accum :: Unbox a
       => (a -> b -> a) -- ^ accumulating function @f@
       -> Vector m a  -- ^ initial vector (of length @m@)
-      -> [(Int,b)]     -- ^ list of index/value pairs (of length @n@)
+      -> [(Finite m,b)]     -- ^ list of index/value pairs (of length @n@)
       -> Vector m a
 accum = V.accum
 {-# inline accum #-}


### PR DESCRIPTION
This involved changing the function in `Generic.Vector.Sized` (using the same `Finite`-to-`Int` logic as `(//)`) and the signatures of the versions in `Vector.Sized`, `Vector.Primitive.Sized`, `Vector.Unbox.Sized`, and `Vector.Storable.Sized`.