### PR TITLE
Add new function: chunks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Add `chunks`.
+
 ## [1.6.1]
 
 - Fix build against Stackage nightly for GHC 9.4.5

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -60,6 +60,7 @@ module Data.Vector.Generic.Sized
   , drop'
   , splitAt
   , splitAt'
+  , chunks
     -- * Construction
     -- ** Initialization
   , empty
@@ -627,6 +628,16 @@ splitAt' :: forall v n m a p. (KnownNat n, VG.Vector v a)
          => p n -> Vector v (n+m) a -> (Vector v n a, Vector v m a)
 splitAt' _ = splitAt
 {-# inline splitAt' #-}
+
+-- | /O(n\/m)/ Split a vector into subvectors of equal length.
+chunks :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a, VG.Vector v (Vector v m a))
+       => Vector v (n*m) a -> Vector v n (Vector v m a)
+chunks (Vector v) = unfoldrN f v
+  where
+    m :: Int
+    m = fromIntegral (natVal (Proxy :: Proxy m))
+    f = first Vector . VG.splitAt m
+{-# inline chunks #-}
 
 --------------------------------------------------------------------------------
 -- * Construction

--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -632,11 +632,10 @@ splitAt' _ = splitAt
 -- | /O(n\/m)/ Split a vector into subvectors of equal length.
 chunks :: forall v n m a. (KnownNat n, KnownNat m, VG.Vector v a, VG.Vector v (Vector v m a))
        => Vector v (n*m) a -> Vector v n (Vector v m a)
-chunks (Vector v) = unfoldrN f v
+chunks (Vector v) = unfoldrN (first Vector . VG.splitAt m) v
   where
     m :: Int
     m = fromIntegral (natVal (Proxy :: Proxy m))
-    f = first Vector . VG.splitAt m
 {-# inline chunks #-}
 
 --------------------------------------------------------------------------------

--- a/src/Data/Vector/Sized.hs
+++ b/src/Data/Vector/Sized.hs
@@ -54,6 +54,7 @@ module Data.Vector.Sized
   , drop'
   , splitAt
   , splitAt'
+  , chunks
     -- * Construction
     -- ** Initialization
   , empty
@@ -465,6 +466,12 @@ splitAt' :: forall n m a p. KnownNat n
          => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
+
+-- | /O(n\/m)/ Split a vector into subvectors of equal length.
+chunks :: forall n m a. (KnownNat n, KnownNat m)
+       => Vector (n*m) a -> Vector n (Vector m a)
+chunks = V.chunks
+{-# INLINE chunks #-}
 
 --------------------------------------------------------------------------------
 -- * Construction

--- a/src/Data/Vector/Storable/Sized.hs
+++ b/src/Data/Vector/Storable/Sized.hs
@@ -55,6 +55,7 @@ module Data.Vector.Storable.Sized
   , drop'
   , splitAt
   , splitAt'
+  , chunks
     -- * Construction
     -- ** Initialization
   , empty
@@ -470,6 +471,12 @@ splitAt' :: forall n m a p. (KnownNat n, Storable a)
          => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
+
+-- | /O(n\/m)/ Split a vector into subvectors of equal length.
+chunks :: forall n m a. (KnownNat n, KnownNat m, Storable a)
+       => Vector (n*m) a -> Vector n (Vector m a)
+chunks = V.chunks
+{-# inline chunks #-}
 
 --------------------------------------------------------------------------------
 -- * Construction

--- a/src/Data/Vector/Unboxed/Sized.hs
+++ b/src/Data/Vector/Unboxed/Sized.hs
@@ -55,6 +55,7 @@ module Data.Vector.Unboxed.Sized
   , drop'
   , splitAt
   , splitAt'
+  , chunks
     -- * Construction
     -- ** Initialization
   , empty
@@ -471,6 +472,12 @@ splitAt' :: forall n m a p. (KnownNat n, Unbox a)
          => p n -> Vector (n+m) a -> (Vector n a, Vector m a)
 splitAt' = V.splitAt'
 {-# inline splitAt' #-}
+
+-- | /O(n\/m)/ Split a vector into subvectors of equal length.
+chunks :: forall n m a. (KnownNat n, KnownNat m, Unbox a)
+       => Vector (n*m) a -> Vector n (Vector m a)
+chunks = V.chunks
+{-# inline chunks #-}
 
 --------------------------------------------------------------------------------
 -- * Construction


### PR DESCRIPTION
This function splits a vector into subvectors of equal length.

## Example interaction

We bring a vector into scope for our testing.

```haskell
ghci> let v = Data.Vector.Sized.iterateN (+1) 1 :: Data.Vector.Sized.Vector 6 Int
ghci> v
Vector [1,2,3,4,5,6]
```

Now we split the vector. How it's split is determined by the output type.

```haskell
ghci> Data.Vector.Sized.chunks v :: Data.Vector.Sized.Vector 3 (Data.Vector.Sized.Vector 2 Int)
Vector [Vector [1,2],Vector [3,4],Vector [5,6]]
ghci> Data.Vector.Sized.chunks v :: Data.Vector.Sized.Vector 2 (Data.Vector.Sized.Vector 3 Int)
Vector [Vector [1,2,3],Vector [4,5,6]]
ghci> Data.Vector.Sized.chunks v :: Data.Vector.Sized.Vector 1 (Data.Vector.Sized.Vector 6 Int)
Vector [Vector [1,2,3,4,5,6]]
```

If the output size is incorrect, a type error is thrown:

```haskell
ghci> Data.Vector.Sized.chunks v :: Data.Vector.Sized.Vector 3 (Data.Vector.Sized.Vector 4 Int)

<interactive>:9:26: error:
    • Couldn't match type ‘6’ with ‘12’
      Expected: Data.Vector.Sized.Vector (3 * 4) Int
        Actual: Data.Vector.Sized.Vector 6 Int
    • In the first argument of ‘Data.Vector.Sized.chunks’, namely ‘v’
      In the expression:
          Data.Vector.Sized.chunks v ::
            Data.Vector.Sized.Vector 3 (Data.Vector.Sized.Vector 4 Int)
      In an equation for ‘it’:
          it
            = Data.Vector.Sized.chunks v ::
                Data.Vector.Sized.Vector 3 (Data.Vector.Sized.Vector 4 Int)
```

## Related functionality

The function `chunks` is the inverse of `concatMap id`.

## Naming

I chose `chunks` instead of the more common `chunksOf` because the usual length argument is missing. I can change it on request.